### PR TITLE
Multiple sequences support

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.h
+++ b/ggml/src/ggml-openvino/ggml-decoder.h
@@ -103,19 +103,19 @@ public:
 
     virtual const std::vector<std::string> & get_model_output_names() const override { return m_model_output_names; }
 
-    virtual int get_context_size() const override { return m_context_size; }
+    virtual int get_ctx_size() const { return m_ctx; }
 
-    virtual int get_context_size_swa() const override { return m_context_size_swa; }
+    virtual int get_ctx_swa_size() const { return m_ctx_swa; }
+
+    virtual int get_ctx_per_seq() const { return m_ctx_per_seq; }
+
+    virtual int get_ctx_per_seq_swa() const { return m_ctx_per_seq_swa; }
+
+    virtual int get_n_seq() const { return m_n_seq; }
 
     virtual int is_swa_layer(int layer) const override {
         return std::find(m_swa_layers.begin(), m_swa_layers.end(), layer) != m_swa_layers.end();
     }
-
-    virtual int get_num_heads() const override { return m_num_heads; }
-
-    virtual int get_num_heads_kv() const override { return m_num_heads_kv; }
-
-    virtual int get_head_size() const override { return m_head_size; }
 
     int get_past_kv_len() const { return m_past_kv_len; }
 
@@ -127,7 +127,7 @@ public:
 
     virtual bool is_static() const override { return m_is_static; }
 
-    ov::PartialShape get_graph_input_shape(const ggml_tensor * src) const;
+    ov::PartialShape get_graph_input_shape(const ggml_tensor * op, const ggml_tensor * input) const;
 
     static void dump_cgraph(const ggml_cgraph * cgraph, std::string & filename);
 
@@ -151,9 +151,10 @@ private:
     static std::vector<size_t> get_stride(const ggml_tensor * tensor);
     static ov::element::Type get_ov_type(const ggml_tensor * tensor);
 
-    // set context_size, num_heads, etc
     void set_llm_params();
     void validate_cgraph() const;
+
+    bool m_is_static = false;
 
     ggml_cgraph * m_cgraph = nullptr;
     ggml_tensor * m_node = nullptr;
@@ -171,17 +172,28 @@ private:
     std::map<std::string, std::shared_ptr<ov::Tensor>> m_model_extra_input_values;
     std::map<std::string, std::shared_ptr<ov::Node>> m_model_weights;
     std::vector<std::string> m_model_output_names;
-    int m_context_size;
-    int m_context_size_swa;
+
+    // Fixed for a model
+    int m_ctx = -1;
+    int m_ctx_swa = -1;
+    int m_ctx_per_seq = -1;
+    int m_ctx_per_seq_swa = -1;
+    int m_n_seq = -1;
+    int m_n_heads = -1;
+    int m_n_heads_kv = -1;
+    int m_head_size = -1;
     std::vector<int> m_swa_layers;
-    int m_num_heads;
-    int m_num_heads_kv;
-    int m_head_size;
-    int m_past_kv_len;
-    int m_input_len;
-    int32_t * m_rope_params;
     std::vector<std::string> m_kv_names;
-    bool m_is_static = false;
+
+    // Changed per inference
+    int m_n_seq_active = -1;
+    int m_seq_active_start = -1;
+    int m_attention_size = -1;
+    int m_attention_size_swa = -1;
+    int m_input_len = -1;
+    int m_token_len_per_seq = -1;
+    int m_past_kv_len = -1;
+    int32_t * m_rope_params = nullptr;
 };
 
 void print_tensor_address_map(const ggml_cgraph * cgraph);

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -329,10 +329,6 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
         GGML_LOG_WARN("OpenVINO backend does not support tensor type %s\n", ggml_type_name(op->type));
         return false;
     }
-    if (op->ne[3] != 1) {
-        GGML_LOG_WARN("OpenVINO backend does not support tensors with ne[3] != 1\n");
-        return false;
-    }
     for (int i = 0; i < GGML_MAX_SRC; i++) {
         auto * src = op->src[i];
         if (src == nullptr) {
@@ -340,10 +336,6 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
         }
         if (supported_types.find(src->type) == supported_types.end()) {
             GGML_LOG_WARN("OpenVINO backend does not support tensor type %s\n", ggml_type_name(src->type));
-            return false;
-        }
-        if (src->ne[3] != 1) {
-            GGML_LOG_WARN("OpenVINO backend does not support tensors with ne[3] != 1\n");
             return false;
         }
         if (ggml_is_quantized(src->type) && src->ne[2] != 1) {

--- a/ggml/src/ggml-openvino/openvino/decoder.hpp
+++ b/ggml/src/ggml-openvino/openvino/decoder.hpp
@@ -58,15 +58,11 @@ public:
     virtual const std::map<std::string, std::shared_ptr<ov::Node>>& get_model_weights() const = 0;
     virtual const std::vector<std::string>& get_model_output_names() const = 0;
 
-    virtual int get_num_heads() const = 0;
-    virtual int get_num_heads_kv() const = 0;
-    virtual int get_head_size() const = 0;
     virtual int32_t* get_rope_params() const = 0;
     virtual std::map<std::string, std::string> get_kv_param_res_names() const = 0;
 
     virtual bool is_static() const = 0;
-    virtual int get_context_size() const = 0;
-    virtual int get_context_size_swa() const = 0;
+
     virtual int is_swa_layer(int layer) const = 0;
 };
 

--- a/ggml/src/ggml-openvino/openvino/op/cont.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/cont.cpp
@@ -27,6 +27,7 @@ OutputVector translate_cont(const NodeContext & context) {
 
     if (op_case == 1) {
         // The input comes from a PERMUTE
+        throw std::runtime_error("Code of this case might be outdated");
         dst_shape[1] = -1;
         res = std::make_shared<ov::op::v1::Reshape>(
             context.get_input(0), ov::op::v0::Constant::create(ov::element::i64, {dst_shape.size()}, dst_shape), false);

--- a/ggml/src/ggml-openvino/openvino/op/glu_geglu.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/glu_geglu.cpp
@@ -26,7 +26,7 @@ OutputVector translate_glu_geglu(const NodeContext & context) {
         src1 = context.get_input(1);
     } else {
         auto combined = context.get_input(0);
-        auto split_axis = ov::op::v0::Constant::create(ov::element::i64, {}, {2});
+        auto split_axis = ov::op::v0::Constant::create(ov::element::i64, {}, {3});
         auto split = std::make_shared<ov::op::v1::Split>(combined, split_axis, 2);
         src0 = split->output(0);
         src1 = split->output(1);

--- a/ggml/src/ggml-openvino/openvino/op/glu_swiglu.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/glu_swiglu.cpp
@@ -26,7 +26,7 @@ OutputVector translate_glu_swiglu(const NodeContext & context) {
         src1 = context.get_input(1);
     } else {
         auto combined = context.get_input(0);
-        auto split_axis = ov::op::v0::Constant::create(ov::element::i64, {}, {2});
+        auto split_axis = ov::op::v0::Constant::create(ov::element::i64, {}, {3});
         auto split = std::make_shared<ov::op::v1::Split>(combined, split_axis, 2);
         src0 = split->output(0);
         src1 = split->output(1);

--- a/ggml/src/ggml-openvino/openvino/op/mulmat.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/mulmat.cpp
@@ -53,6 +53,7 @@ OutputVector translate_mulmat(const NodeContext & context) {
     Output<Node> Z = A_batch_larger ? B : A;
     int64_t factor = A_batch_larger ? A_batch / B_batch : B_batch / A_batch;
     if (factor > 1) {
+        // TODO code is outdated
         auto A_batch_node = ov::op::v0::Constant::create(ov::element::i64, {1}, std::vector<int64_t>{A_batch});
         auto B_batch_node = ov::op::v0::Constant::create(ov::element::i64, {1}, std::vector<int64_t>{B_batch});
         auto factor_node = ov::op::v0::Constant::create(ov::element::i64, {1}, std::vector<int64_t>{factor});

--- a/ggml/src/ggml-openvino/openvino/op/permute.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/permute.cpp
@@ -52,7 +52,7 @@ OutputVector translate_permute(const NodeContext & context) {
         auto output_shape = context.get_output_shape(0).to_shape();
         int64_t head_size = output_shape[3];
         int64_t n_heads = output_shape[1];
-        int64_t ctx_per_seq = cache_shape[2].get_length();
+        int64_t ctx_per_seq = cache_shape[2].is_static() ? cache_shape[2].get_length() : -1;
         int64_t n_seq = cache_shape[1].get_length();
 
         Output<Node> attention_size;

--- a/ggml/src/ggml-openvino/openvino/op/permute.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/permute.cpp
@@ -56,9 +56,7 @@ OutputVector translate_permute(const NodeContext & context) {
         int64_t n_seq = cache_shape[1].get_length();
 
         Output<Node> attention_size;
-        if (context.is_static()) {
-            attention_size = ov::op::v0::Constant::create(ov::element::i64, {1}, {INT_MAX});
-        } else if (op_case == 2) {
+        if (op_case == 2) {
             attention_size = context.get_input("attention_size");
         } else {
             attention_size = context.get_input("attention_size_swa");

--- a/ggml/src/ggml-openvino/openvino/op/permute.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/permute.cpp
@@ -6,12 +6,12 @@
 #include <cstdint>
 #include <memory>
 #include <openvino/core/node.hpp>
+#include <openvino/op/add.hpp>
 #include <openvino/op/concat.hpp>
 #include <openvino/op/constant.hpp>
 #include <openvino/op/reshape.hpp>
 #include <openvino/op/slice.hpp>
 #include <openvino/op/transpose.hpp>
-#include <openvino/op/unsqueeze.hpp>
 
 namespace ov {
 namespace frontend {
@@ -22,12 +22,64 @@ OutputVector translate_permute(const NodeContext & context) {
     num_inputs_check(context, 1, 1);
 
     int op_case = context.get_op_case();
-    FRONT_END_CHECK_IMPLEMENTED(op_case == 1 || op_case == 2 || op_case == 3, "Unsupported PERMUTE case");
-    ov::Output<Node> res;
-    auto zero = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
+    FRONT_END_CHECK_IMPLEMENTED(op_case == 1 || op_case == 2 || op_case == 3 || op_case == 4,
+                                "Unsupported PERMUTE case");
 
+    ov::Output<Node> res;
     auto src = context.get_input(0);
-    res = std::make_shared<ov::op::v1::Transpose>(src, ov::op::v0::Constant::create(ov::element::i64, {3}, {1, 0, 2}));
+    auto perm = ov::op::v0::Constant::create(ov::element::i64, {4}, {0, 2, 1, 3});
+
+    if (op_case == 1) {
+        res = std::make_shared<ov::op::v1::Transpose>(src, perm);
+    } else if (op_case == 4) {
+        auto output_shape = context.get_output_shape(0).to_shape();
+        auto n_heads = ov::op::v0::Constant::create(ov::element::i64, {1}, {output_shape[1]});
+        auto head_size = ov::op::v0::Constant::create(ov::element::i64, {1}, {output_shape[3]});
+        auto n_seq_active = context.get_input("n_seq_active");
+        auto neg_one = ov::op::v0::Constant::create(ov::element::i64, {1}, {-1});
+
+        auto new_shape =
+            std::make_shared<ov::op::v0::Concat>(ov::OutputVector{n_seq_active, neg_one, n_heads, head_size}, 0);
+
+        // // Alternative
+        // auto zero = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
+        // auto new_shape = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{n_seq_active, neg_one, zero, zero}, 0);
+
+        auto reshaped = std::make_shared<ov::op::v1::Reshape>(src, new_shape, true);
+        res = std::make_shared<ov::op::v1::Transpose>(reshaped, perm);
+    } else {
+        auto cache_shape = src.get_partial_shape();
+        auto output_shape = context.get_output_shape(0).to_shape();
+        int64_t head_size = output_shape[3];
+        int64_t n_heads = output_shape[1];
+        int64_t ctx_per_seq = cache_shape[2].get_length();
+        int64_t n_seq = cache_shape[1].get_length();
+
+        Output<Node> attention_size;
+        if (context.is_static()) {
+            attention_size = ov::op::v0::Constant::create(ov::element::i64, {1}, {INT_MAX});
+        } else if (op_case == 2) {
+            attention_size = context.get_input("attention_size");
+        } else {
+            attention_size = context.get_input("attention_size_swa");
+        }
+
+        // 1. reshape to [n_seq, ctx_per_seq, n_heads, head_size]
+        // 2. slice out the active sequences
+        // 3. slice out the attention part in each sequence
+        // 4. permute
+        auto seq_active_start = context.get_input("seq_active_start");
+        auto seq_active_end = context.get_input("seq_active_end");
+
+        auto zero = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
+        auto one = ov::op::v0::Constant::create(ov::element::i64, {1}, {1});
+
+        auto src_reshaped = std::make_shared<ov::op::v1::Reshape>(
+            src, ov::op::v0::Constant::create(ov::element::i64, {4}, {n_seq, ctx_per_seq, n_heads, head_size}), false);
+        auto slice1 = std::make_shared<ov::op::v8::Slice>(src_reshaped, seq_active_start, seq_active_end, one, zero);
+        auto slice2 = std::make_shared<ov::op::v8::Slice>(slice1, zero, attention_size, one, one);
+        res = std::make_shared<ov::op::v1::Transpose>(slice2, perm);
+    }
     return rename_outputs_with_suffix({res}, context.get_name());
 }
 

--- a/ggml/src/ggml-openvino/openvino/op/reshape.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/reshape.cpp
@@ -7,8 +7,10 @@
 #include <openvino/core/node.hpp>
 #include <openvino/core/node_output.hpp>
 #include <openvino/frontend/exception.hpp>
+#include <openvino/op/concat.hpp>
 #include <openvino/op/constant.hpp>
 #include <openvino/op/reshape.hpp>
+#include <stdexcept>
 #include <vector>
 
 namespace ov {
@@ -23,22 +25,43 @@ OutputVector translate_reshape(const NodeContext & context) {
     }
 
     int op_case = context.get_op_case();
-    FRONT_END_CHECK_IMPLEMENTED(op_case == 1 || op_case == 2 || op_case == 3 || op_case == 4,
-                                "Unsupported RESHAPE case");
+    FRONT_END_CHECK_IMPLEMENTED(
+        op_case == 1 || op_case == 2 || op_case == 3 || op_case == 4 || op_case == 5 || op_case == 6,
+        "Unsupported RESHAPE case");
 
     auto output_shape = context.get_output_shape(0).to_shape();
     std::shared_ptr<ov::Node> new_shape_node;
     if (op_case == 1) {
         new_shape_node = ov::op::v0::Constant::create(
-            ov::element::i64, {3}, std::vector<int64_t>{-1, (int64_t) output_shape[1], (int64_t) output_shape[2]});
+            ov::element::i64, {4},
+            std::vector<int64_t>{(int64_t) output_shape[0], -1, (int64_t) output_shape[2], (int64_t) output_shape[3]});
+
     } else if (op_case == 2) {
         new_shape_node = ov::op::v0::Constant::create(
-            ov::element::i64, {3}, std::vector<int64_t>{(int64_t) output_shape[0], -1, (int64_t) output_shape[2]});
+            ov::element::i64, {4},
+            std::vector<int64_t>{(int64_t) output_shape[0], (int64_t) output_shape[1], -1, (int64_t) output_shape[3]});
+
     } else if (op_case == 3) {
-        new_shape_node =
-            ov::op::v0::Constant::create(ov::element::i64, {3}, std::vector<int64_t>{(int64_t) output_shape[0], -1, 1});
+        throw std::runtime_error("might be outdated RESHAPE case");
+        new_shape_node = ov::op::v0::Constant::create(
+            ov::element::i64, {4}, std::vector<int64_t>{(int64_t) output_shape[0], (int64_t) output_shape[1], -1, 1});
+
     } else if (op_case == 4) {
         return {context.get_input(0).get_node_shared_ptr()->input_value(0)};
+
+    } else if (op_case == 5) {
+        std::vector<int64_t> shape_vec = {1, 1, -1, (int64_t) context.get_output_shape(0).to_shape()[3]};
+        new_shape_node = ov::op::v0::Constant::create(ov::element::i64, {4}, shape_vec);
+
+        // // Alternative
+        // auto token_len = context.get_input("token_len");
+        // auto emb_size =
+        //     ov::op::v0::Constant::create(ov::element::i64, {1}, {(int64_t) context.get_output_shape(0).to_shape()[3]});
+        // auto one = ov::op::v0::Constant::create(ov::element::i64, {1}, {1});
+        // new_shape_node = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{one, one, token_len, emb_size}, 0);
+
+    } else if (op_case == 6) {
+        new_shape_node = ov::op::v0::Constant::create(ov::element::i64, {4}, context.get_output_shape(0).to_shape());
     }
     auto res = std::make_shared<ov::op::v1::Reshape>(context.get_input(0), new_shape_node, false);
     return rename_outputs_with_suffix({res}, context.get_name());

--- a/ggml/src/ggml-openvino/openvino/op/softmax.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/softmax.cpp
@@ -23,6 +23,7 @@ namespace ggml {
 namespace op {
 
 OutputVector translate_soft_max(const NodeContext & context) {
+    // TODO code is outdated
     num_inputs_check(context, 1, 2);
 
     auto input_node = context.get_input(0).get_node_shared_ptr();

--- a/ggml/src/ggml-openvino/openvino/op/transpose.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/transpose.cpp
@@ -12,8 +12,8 @@ namespace op {
 OutputVector translate_transpose(const NodeContext & context) {
     num_inputs_check(context, 1, 1);
 
-    auto res = std::make_shared<ov::op::v1::Transpose>(context.get_input(0),
-                                                       ov::op::v0::Constant::create(ov::element::i64, {3}, {0, 2, 1}));
+    auto res = std::make_shared<ov::op::v1::Transpose>(
+        context.get_input(0), ov::op::v0::Constant::create(ov::element::i64, {4}, {0, 1, 3, 2}));
     return rename_outputs_with_suffix({res}, context.get_name());
 }
 

--- a/ggml/src/ggml-openvino/openvino/op/view.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/view.cpp
@@ -11,7 +11,7 @@ OutputVector translate_view(const NodeContext & context) {
 
     if (context.get_op_case() == 2) {
         auto dst_shape = context.get_output_shape(0).to_shape();
-        return rename_outputs_with_suffix({process_view_input(context, 0, dst_shape[1] * dst_shape[2])},
+        return rename_outputs_with_suffix({process_view_input(context, 0, dst_shape[2] * dst_shape[3])},
                                           context.get_name());
     }
     return {context.get_input(0)};

--- a/ggml/src/ggml-openvino/openvino/translate_session.cpp
+++ b/ggml/src/ggml-openvino/openvino/translate_session.cpp
@@ -154,7 +154,9 @@ std::shared_ptr<Model> TranslateSession::translate_graph(const frontend::InputMo
     }
 
     for (const auto & it : ggml_model_decoder->get_model_extra_inputs()) {
-        params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(it.second));
+        if (std::dynamic_pointer_cast<ov::op::v0::Parameter>(it.second)) {
+            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(it.second));
+        }
         (*tensor_map)[it.first] = it.second;
     }
 

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -129,26 +129,27 @@ enum ggml_status openvino_frontend_compute(ggml_backend_t backend, ggml_cgraph *
             ov_input_names_cache[cgraph] = ov_input_names;
             ov_output_names_cache[cgraph] = ov_output_names;
 
-            // Set output tensors (for NPU) and kvcache i/o tensors once and for all
-            for (size_t i = 0; i < ov_output_names.size(); i++) {
-                auto output_name = ov_output_names[i];
-                if (is_static || output_name.find("cache") == 0) {
-                    auto output_tensor = get_ov_output_tensor(ggml_decoder, ov_output_names[i]);
-                    infer_request->set_output_tensor(i, output_tensor);
-                }
-            }
-            for (size_t i = 0; i < ov_input_names.size(); i++) {
-                auto param_name = ov_input_names[i];
-                if (param_name.find("cache") == 0) {
-                    ov::Tensor input_tensor;
-                    if (is_static) {
-                        input_tensor = get_ov_input_tensor_static(ggml_decoder, param_name, 0, 0);
-                    } else {
-                        input_tensor = get_ov_input_tensor(ggml_decoder, param_name);
-                    }
-                    infer_request->set_input_tensor(i, input_tensor);
-                }
-            }
+            // // Set output tensors (for NPU) and kvcache i/o tensors once and for all
+            // // Note: does not seem to improve perf on CPU/GPU, but it breaks llama-bench, so disabled it
+            // for (size_t i = 0; i < ov_output_names.size(); i++) {
+            //     auto output_name = ov_output_names[i];
+            //     if (is_static || output_name.find("cache") == 0) {
+            //         auto output_tensor = get_ov_output_tensor(ggml_decoder, ov_output_names[i]);
+            //         infer_request->set_output_tensor(i, output_tensor);
+            //     }
+            // }
+            // for (size_t i = 0; i < ov_input_names.size(); i++) {
+            //     auto param_name = ov_input_names[i];
+            //     if (param_name.find("cache") == 0) {
+            //         ov::Tensor input_tensor;
+            //         if (is_static) {
+            //             input_tensor = get_ov_input_tensor_static(ggml_decoder, param_name, 0, 0);
+            //         } else {
+            //             input_tensor = get_ov_input_tensor(ggml_decoder, param_name);
+            //         }
+            //         infer_request->set_input_tensor(i, input_tensor);
+            //     }
+            // }
         }
     }
 
@@ -158,9 +159,6 @@ enum ggml_status openvino_frontend_compute(ggml_backend_t backend, ggml_cgraph *
     if (!is_static) {
         for (size_t i = 0; i < ov_input_names.size(); i++) {
             auto param_name = ov_input_names[i];
-            if (param_name.find("cache") == 0) {
-                continue;
-            }
             auto input_tensor = get_ov_input_tensor(ggml_decoder, param_name);
             infer_request->set_input_tensor(i, input_tensor);
 
@@ -188,9 +186,6 @@ enum ggml_status openvino_frontend_compute(ggml_backend_t backend, ggml_cgraph *
         for (int j = 0; j < input_len; j++) {
             for (size_t i = 0; i < ov_input_names.size(); i++) {
                 auto param_name = ov_input_names[i];
-                if (param_name.find("cache") == 0) {
-                    continue;
-                }
                 auto input_tensor = get_ov_input_tensor_static(ggml_decoder, param_name, j, input_len);
                 infer_request->set_input_tensor(i, input_tensor);
 


### PR DESCRIPTION
CPU and GPU
- llama-server -np > 1 support
- llama-perplexity support
- llama-bench support (-fa 1 is needed to use flash attention)
- GPU accuracy issue on quantized models (WA: OV_GPU_DISABLE_HORIZONTAL_FC_FUSION)
- Need to test perf: small regression on CPU, large regression on GPU

NPU
- llama-server -np > 1 and llama-perplexity not supported
