### PR TITLE
Fix - unsetenv()

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -70,7 +70,7 @@ GgmlOvDecoder::GgmlOvDecoder(ggml_cgraph * cgraph,
 	    #else
 		    unsetenv("GGML_OPENVINO_PRINT_CGRAPH_TENSOR_ADDRESS");
 	    #endif
-            print_tensor_address_map(cgraph);
+        print_tensor_address_map(cgraph);
     }
 
     set_llm_params();


### PR DESCRIPTION
Hitting following error while compiling on windows:

error C3861: 'unsetenv': identifier not found


Reason: unsetenv() is a POSIX function; it doesn’t exist on Windows. Visual Studio (MSVC) won’t recognize it.

Fix: Use _putenv_s() (Windows equivalent)
This is supported by MSVC and achieves the same effect: it removes the environment variable from the process environment.

Maintains cross-platform compatibility.