### PR TITLE
Extract u4/u8 zero point directly instead of FP bias

### DIFF
--- a/ggml/src/ggml-openvino/ggml-quants.hpp
+++ b/ggml/src/ggml-openvino/ggml-quants.hpp
@@ -8,52 +8,52 @@
 
 void unpack_32_4(const uint8_t* data, uint8_t* dst);
 
-void extract_q4_0_data(const ggml_tensor* tensor,
-                       ov::Tensor& weights_arr,
-                       ov::Tensor& scales_arr,
-                       ov::Tensor& biases_arr);
+void extract_q4_0_data(const ggml_tensor * tensor,
+                       ov::Tensor & weights_arr,
+                       ov::Tensor & scales_arr,
+                       ov::Tensor & zp_arr);
 
-void extract_q4_1_data(const ggml_tensor* tensor,
-                       ov::Tensor& weights_arr,
-                       ov::Tensor& scales_arr,
-                       ov::Tensor& biases_arr);
+void extract_q4_1_data(const ggml_tensor * tensor,
+                       ov::Tensor & weights_arr,
+                       ov::Tensor & scales_arr,
+                       ov::Tensor & zp_arr);
 
-void extract_q8_0_data(const ggml_tensor* tensor,
-                       ov::Tensor& weights_arr,
-                       ov::Tensor& scales_arr,
-                       ov::Tensor& biases_arr);
+void extract_q8_0_data(const ggml_tensor * tensor,
+                       ov::Tensor & weights_arr,
+                       ov::Tensor & scales_arr,
+                       ov::Tensor & zp_arr);
 
 void unpack_256_4(const uint8_t* data, uint8_t* dst);
 
-void extract_q4_k_data(const ggml_tensor* tensor,
-                       ov::Tensor& weights_arr,
-                       ov::Tensor& scales_arr,
-                       ov::Tensor& biases_arr);
+void extract_q4_k_data(const ggml_tensor * tensor,
+                       ov::Tensor & weights_arr,
+                       ov::Tensor & scales_arr,
+                       ov::Tensor & zp_arr);
 
-void extract_q5_k_data(const ggml_tensor* tensor,
-                       ov::Tensor& weights_arr,
-                       ov::Tensor& scales_arr,
-                       ov::Tensor& biases_arr);
+void extract_q5_k_data(const ggml_tensor * tensor,
+                       ov::Tensor & weights_arr,
+                       ov::Tensor & scales_arr,
+                       ov::Tensor & zp_arr);
 
-void extract_q6_k_data(const ggml_tensor* tensor,
-                       ov::Tensor& weights_arr,
-                       ov::Tensor& scales_arr,
-                       ov::Tensor& biases_arr);
+void extract_q6_k_data(const ggml_tensor * tensor,
+                       ov::Tensor & weights_arr,
+                       ov::Tensor & scales_arr,
+                       ov::Tensor & zp_arr);
 
 static constexpr size_t GGML_QUANTIZATION_GROUP_SIZE = 32;
 
-ov::Output<ov::Node> make_int8_weights(ov::Tensor& weight,
-                                       ov::Tensor& scales,
-                                       ov::Tensor& biases,
+ov::Output<ov::Node> make_int8_weights(ov::Tensor & weight,
+                                       ov::Tensor & scales,
+                                       ov::Tensor & zp,
                                        size_t group_size = GGML_QUANTIZATION_GROUP_SIZE);
 
-ov::Output<ov::Node> make_int4_weights(ov::Tensor& weight,
-                                       ov::Tensor& scales,
-                                       ov::Tensor& biases,
+ov::Output<ov::Node> make_int4_weights(ov::Tensor & weight,
+                                       ov::Tensor & scales,
+                                       ov::Tensor & zp,
                                        size_t group_size = GGML_QUANTIZATION_GROUP_SIZE);
 
 // Extract quantized weights from tensor and create weight subgraph
-// If weights/scales/biases are provided (non-empty), uses them as output buffers
+// If weights/scales/zp are provided (non-empty), uses them as output buffers
 // Otherwise allocates new ov::Tensors internally
 // Returns the weight node (make_int4_weights or make_int8_weights result)
 std::shared_ptr<ov::Node> extract_quantized_weights(
@@ -61,10 +61,10 @@ std::shared_ptr<ov::Node> extract_quantized_weights(
     const void * data,  // Source data pointer (may differ from tensor->data)
     ov::Tensor & weights,
     ov::Tensor & scales,
-    ov::Tensor & biases);
+    ov::Tensor & zp);
 
 // Requantize weights from tensor to target format, writing to provided buffers
-// For F16 target, only weights buffer is used (scales/biases ignored)
+// For F16 target, only weights buffer is used (scales/zp ignored)
 // Returns the weight node
 std::shared_ptr<ov::Node> requantize_to_buffers(const ggml_tensor * tensor,
                                                 const void * data,  // Source data pointer
@@ -72,7 +72,7 @@ std::shared_ptr<ov::Node> requantize_to_buffers(const ggml_tensor * tensor,
                                                 int64_t block_size,
                                                 ov::Tensor & weights,
                                                 ov::Tensor & scales,
-                                                ov::Tensor & biases);
+                                                ov::Tensor & zp);
 
 // Process weight tensor and create an OpenVINO constant node
 // Handles F16/F32/BF16 and quantized weights, with optional requantization
@@ -84,11 +84,23 @@ std::shared_ptr<ov::Node> process_weight_tensor(
     const void * data,                  // Source data pointer (may differ from tensor->data)
     void * output_base_ptr = nullptr);  // Base pointer for output buffers (or nullptr for internal allocation)
 
-void quantize_q4_0(const float* x, ov::Tensor& weights_arr, ov::Tensor& scales_arr, ov::Tensor& biases_arr, int64_t k,
+void quantize_q4_0(const float * x,
+                   ov::Tensor & weights_arr,
+                   ov::Tensor & scales_arr,
+                   ov::Tensor & zp_arr,
+                   int64_t k,
                    int64_t qk);
-void quantize_q8_1(const float* x, ov::Tensor& weights_arr, ov::Tensor& scales_arr, ov::Tensor& biases_arr, int64_t k,
+void quantize_q8_1(const float * x,
+                   ov::Tensor & weights_arr,
+                   ov::Tensor & scales_arr,
+                   ov::Tensor & zp_arr,
+                   int64_t k,
                    int64_t qk);
-void quantize_q8_0(const float* x, ov::Tensor& weights_arr, ov::Tensor& scales_arr, ov::Tensor& biases_arr, int64_t k,
+void quantize_q8_0(const float * x,
+                   ov::Tensor & weights_arr,
+                   ov::Tensor & scales_arr,
+                   ov::Tensor & zp_arr,
+                   int64_t k,
                    int64_t qk);
 
 namespace ov {


### PR DESCRIPTION
OV uses a u4/u8 zero-point tensor for dequantization, while GGUF models store FP biases. The current code first extracts an FP bias ov::Tensor from the model and then creates a separate zero-point tensor during model conversion. This PR changes the flow so that the zero-point tensor is created directly during model loading.

On top of PR https://github.com/ravi9/llama.cpp/pull/40