### PR TITLE
Fix opencl dependencies in openvino.Dockerfile

### DIFF
--- a/.devops/openvino.Dockerfile
+++ b/.devops/openvino.Dockerfile
@@ -23,6 +23,10 @@ RUN apt-get update && \
         ninja-build \
         build-essential \
         libtbb12 \
+        ocl-icd-opencl-dev \
+        opencl-headers \
+        opencl-clhpp-headers \
+        intel-opencl-icd \
         libcurl4-openssl-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Overview
When following the instructions in [build instructions](https://github.com/ravi9/llama.cpp/blob/dev_backend_openvino/docs/build.md#openvino). Specifically those for running the llama-server in docker:
```
docker build --target=server -t llama-openvino:server -f .devops/openvino.Dockerfile .
```
I ran into the issue of missing opencl dependencies.

I then simply copied the dependencies from the same build instructions [here](https://github.com/ravi9/llama.cpp/blob/dev_backend_openvino/docs/build.md#prerequisites)

>     sudo apt install ocl-icd-opencl-dev opencl-headers opencl-clhpp-headers intel-opencl-icd
Into the Dockerfile.

After applying this changes the docker image gets built successfully.