### PR TITLE
Fix test-backend-ops for OV GPU LNL

### DIFF
--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -468,7 +468,11 @@ enum ggml_status naive_compute(ggml_cgraph * cgraph,
 
     ov::InferRequest infer_request;
     auto remote_context = ggml_openvino_get_remote_context();
-    core.set_property(device, ov::hint::execution_mode(ov::hint::ExecutionMode::ACCURACY));
+    if (cgraph->nodes[0]->op == GGML_OP_MUL_MAT) {
+        core.set_property(device, ov::hint::execution_mode(ov::hint::ExecutionMode::PERFORMANCE));
+    } else {
+        core.set_property(device, ov::hint::execution_mode(ov::hint::ExecutionMode::ACCURACY));
+    }
     if (remote_context.has_value()) {
         infer_request = core.compile_model(model, remote_context.value(), config).create_infer_request();
     } else {

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -469,6 +469,7 @@ enum ggml_status naive_compute(ggml_cgraph * cgraph,
     ov::InferRequest infer_request;
     auto remote_context = ggml_openvino_get_remote_context();
     if (cgraph->nodes[0]->op == GGML_OP_MUL_MAT) {
+        // TODO ACCURACY hint triggers a bug in GPU plugin/driver on Lunar Lake. Remove once CVS-182166 is resolved
         core.set_property(device, ov::hint::execution_mode(ov::hint::ExecutionMode::PERFORMANCE));
     } else {
         core.set_property(device, ov::hint::execution_mode(ov::hint::ExecutionMode::ACCURACY));


### PR DESCRIPTION
Workaround to fix CL_OUT_OF_RESOURCE in LNL
[[CVS-182166] [GPU] CL_OUT_OF_RESOURCES when executing single MatMul op multiple times in fp32 - IT JIRA (Supports IC/ITS Data)](https://jira.devtools.intel.com/browse/CVS-182166)