### PR TITLE
Enable additional mul_mat tests and add tensor data saving function

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -860,9 +860,6 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         if (op->src[0]->ne[3] != op->src[1]->ne[3] && op->src[0]->ne[3] != 1 && op->src[1]->ne[3] != 1) {
             return true;
         }
-        if (op->src[0]->op == GGML_OP_PERMUTE || op->src[1]->op == GGML_OP_PERMUTE) {
-            return true;
-        }
         if (ggml_is_quantized(op->src[0]->type) && op->src[0]->ne[1] == 1) {
             // MUL_MAT(type_a=q4_0,type_b=f32,m=1,n=2048,k=8192,bs=[1,1],nr=[1,1],per=[0,1,2,3],k_v=0,o=1)
             // triggers a bug in ov matmul_shape_inference.hpp

--- a/ggml/src/ggml-openvino/openvino/op/permute.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/permute.cpp
@@ -5,6 +5,7 @@
 #include <climits>
 #include <cstdint>
 #include <memory>
+#include <vector>
 #include <openvino/core/node.hpp>
 #include <openvino/op/add.hpp>
 #include <openvino/op/concat.hpp>
@@ -27,7 +28,14 @@ OutputVector translate_permute(const NodeContext & context) {
 
     ov::Output<Node> res;
     auto src = context.get_input(0);
-    auto perm = ov::op::v0::Constant::create(ov::element::i64, {4}, {0, 2, 1, 3});
+    std::vector<int64_t> perm_values{0, 2, 1, 3};
+    const int32_t* op_params = context.get_output_op_params();
+    if (op_params != nullptr) {
+        for (size_t i = 0; i < perm_values.size(); ++i) {
+            perm_values[i] = static_cast<int64_t>(perm_values.size() - 1 - op_params[perm_values.size() - 1 - i]);
+        }
+    }
+    auto perm = ov::op::v0::Constant::create(ov::element::i64, {4}, perm_values);
 
     if (op_case == 1 || context.is_stateful()) {
         res = std::make_shared<ov::op::v1::Transpose>(src, perm);

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -521,14 +522,23 @@ enum ggml_status naive_compute(ggml_cgraph * cgraph,
         infer_request->set_input_tensor(i, input_tensor);
     }
 
-    auto ov_results = model->get_results();
-    for (size_t i = 0; i < ov_results.size(); i++) {
-        auto * ggml_tensor = decoder->get_model_outputs().at(ov_results[i]->get_friendly_name());
-        auto output_tensor = create_ov_output_tensor(decoder, infer_request, i, ggml_tensor);
-        infer_request->set_output_tensor(i, output_tensor);
-    }
+    // TODO: Need to check why set_output_tensor() doesn't work in naive mode. For now, we will create output tensors after infer() and copy data back to ggml tensors.
+    // auto ov_results = model->get_results();
+    // for (size_t i = 0; i < ov_results.size(); i++) {
+    //     auto * ggml_tensor = decoder->get_model_outputs().at(ov_results[i]->get_friendly_name());
+    //     auto output_tensor = create_ov_output_tensor(decoder, infer_request, i, ggml_tensor);
+    //     infer_request->set_output_tensor(i, output_tensor);
+    // }
 
     infer_request->infer();
+
+    // get output tensor from infer_request and copy data back to ggml_tensor
+    auto ov_results = model->get_results();
+    for (size_t i = 0; i < ov_results.size(); i++) {
+        auto output_tensor = infer_request->get_output_tensor(i);
+        auto * ggml_tensor = decoder->get_model_outputs().at(ov_results[i]->get_friendly_name());
+        std::memcpy(ggml_tensor->data, output_tensor.data(), output_tensor.get_byte_size());
+    }
     return GGML_STATUS_SUCCESS;
 }
 
@@ -694,6 +704,68 @@ size_t checksum(const void * data, size_t size) {
         sum += bytes[i];
     }
     return sum;
+}
+
+bool save_ggml_tensor_data_to_txt(const ggml_tensor * tensor, const std::string & file_path) {
+    if (tensor == nullptr || tensor->data == nullptr) {
+        return false;
+    }
+
+    std::ofstream out(file_path);
+    if (!out.is_open()) {
+        return false;
+    }
+
+    const size_t n = ggml_nelements(tensor);
+    out << "name: " << tensor->name
+        << ", type: " << ggml_type_name(tensor->type)
+        << ", shape: [" << tensor->ne[0] << ", " << tensor->ne[1] << ", " << tensor->ne[2] << ", " << tensor->ne[3]
+        << "]"
+        << ", elements: " << n
+        << ", data:" << '\n';
+
+    switch (tensor->type) {
+    case GGML_TYPE_F32: {
+        const auto * data = static_cast<const float *>(tensor->data);
+        for (size_t i = 0; i < n; ++i) {
+            out << data[i] << '\n';
+        }
+        break;
+    }
+    case GGML_TYPE_F16: {
+        const auto * data = static_cast<const ggml_fp16_t *>(tensor->data);
+        for (size_t i = 0; i < n; ++i) {
+            out << ggml_fp16_to_fp32(data[i]) << '\n';
+        }
+        break;
+    }
+    case GGML_TYPE_BF16: {
+        const auto * data = static_cast<const ggml_bf16_t *>(tensor->data);
+        for (size_t i = 0; i < n; ++i) {
+            out << ggml_bf16_to_fp32(data[i]) << '\n';
+        }
+        break;
+    }
+    case GGML_TYPE_I32: {
+        const auto * data = static_cast<const int32_t *>(tensor->data);
+        for (size_t i = 0; i < n; ++i) {
+            out << data[i] << '\n';
+        }
+        break;
+    }
+    case GGML_TYPE_I64: {
+        const auto * data = static_cast<const int64_t *>(tensor->data);
+        for (size_t i = 0; i < n; ++i) {
+            out << data[i] << '\n';
+        }
+        break;
+    }
+    default:
+        out << "unsupported tensor type for text dump" << '\n';
+        return false;
+    }
+
+    return true;
 }
 
 void print_input_tensor_info(const std::string & name, const ov::Tensor & tensor) {

--- a/ggml/src/ggml-openvino/utils.h
+++ b/ggml/src/ggml-openvino/utils.h
@@ -67,6 +67,8 @@ enum ggml_status ov_graph_compute_static(struct ggml_cgraph * cgraph, std::share
 
 size_t checksum(const void * data, size_t size);
 
+bool save_ggml_tensor_data_to_txt(const ggml_tensor * tensor, const std::string & file_path);
+
 void print_input_tensor_info(const std::string & name, const ov::Tensor & tensor);
 
 void print_output_tensor_info(const std::string & name, const ov::Tensor & tensor, const void * output_dst);


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the OpenVINO integration in the `ggml` library, focusing on tensor handling, operation support, and utility enhancements. The most important changes include fixing tensor output handling in naive compute mode, improving permute operation translation, and adding a utility for saving tensor data to text files.

**Tensor output handling and utilities:**
* Fixed the output tensor handling in `naive_compute` by copying data directly from the OpenVINO output tensor to the `ggml_tensor` after inference, instead of relying on `set_output_tensor`, which currently does not work in naive mode.
* Added a new utility function `save_ggml_tensor_data_to_txt` for exporting tensor data to a text file, supporting multiple tensor types. Declaration added to `utils.h`. [[1]](diffhunk://#diff-f03e5dcc8ad94468267d70b7a2ff7926977ecbc1395285e416ee5ad3b13fab78R709-R770) [[2]](diffhunk://#diff-201d067dc64c3a1a706bd3503e92ecf1ad8e1fd40abe9828c0c38efe3cd94ad7R70-R71)

**Operation support and translation:**
* Improved translation of the permute operation in `permute.cpp` by dynamically constructing the permutation vector from operation parameters if available, allowing more flexible permute handling.
* Removed the check for unsupported permute operations in `is_op_unsupported_case`, enabling permute operations to be processed by OpenVINO.

**General improvements:**
* Added missing include for `<vector>` in `permute.cpp` to support dynamic permutation vector construction.
* Added missing include for `<fstream>` in `utils.cpp` to support file output in the new tensor saving utility.…bugging

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
