### PR TITLE
llama-cli fix for NPU

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -381,7 +381,7 @@ ov::PartialShape GgmlOvDecoder::get_graph_input_shape(const ggml_tensor * op, co
     } else {
         input_shape = ov::PartialShape{get_shape(input)};
     }
-    if (dynamic_dim_index != -1) {
+    if (dynamic_dim_index != -1 && !m_is_static) {
         input_shape[3 - dynamic_dim_index] = -1;
     }
     return input_shape;


### PR DESCRIPTION
I observed the error below when testing llama-cli with NPU:
```
OpenVINO: using device NPU

Loading model... /GGML OpenVINO backend ov::Exception: Exception from src/inference/src/cpp/core.cpp:116:
Exception from src/inference/src/dev/plugin.cpp:53:
Exception from src/core/src/partial_shape.cpp:266:
to_shape was called on a dynamic shape.



graph_compute: ggml_backend_sched_graph_compute_async failed with error -1
process_ubatch: failed to compute graph, compute status: -1
llama_decode: failed to decode, ret = -3
./run.sh: line 19: 17676 Segmentation fault      (core dumped) ./llama.cpp/build/ReleaseOV/bin/llama-cli -m $1 -c 1024
```
Reproducer:
`./llama.cpp/build/ReleaseOV/bin/llama-cli -m /home/mcavus/llama.cpp_test/models/Llama-3.2-1B-Instruct.q4_0.gguf -c 1024`

@zhaixuejun1993 can you please check if it impacts anything related to the recent dynamic dims update?
