### PR TITLE
Move dynamic dims computation for graph mismatch handling

### DIFF
--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -85,10 +85,10 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
     bool stateful = r_ctx->stateful;
     static auto is_static = false;
 
-    bool model_is_splitted = is_model_splitted(cgraph);
-
-    if (is_naive(cgraph) && !model_is_splitted) {
-        return naive_compute(cgraph, core, device, config);
+    if (is_naive(cgraph)) {
+        if (!is_model_splitted(cgraph)) {
+            return naive_compute(cgraph, core, device, config);
+        }
     }
 
     auto start_time = ggml_time_us();
@@ -179,6 +179,7 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
             compile_end_time = decoder_end_time;
         } else {
             r_ctx->infer_request_cache.erase(key);
+            bool model_is_splitted = is_model_splitted(cgraph);
 
             std::shared_ptr<ov::Model> model;
             auto model_weights = GgmlOvDecoder::create_weight_nodes(cgraph);


### PR DESCRIPTION
This pull request makes targeted adjustments to the `ov_graph_compute_dynamic` function in `ggml/src/ggml-openvino/utils.cpp`, primarily refining the logic for handling "naive" computation and the "model is splitted" check. The changes simplify the conditional structure and ensure that the `model_is_splitted` variable is only declared where needed.

Logic simplification and code cleanup:

* Refactored the conditional logic in the "naive" code path to check for `is_model_splitted(cgraph)` only within the `is_naive(cgraph)` block, removing the unnecessary `model_is_splitted` variable declaration at the top of the function.
* Moved the declaration of `model_is_splitted` to a more localized scope, just before it is used, improving code clarity and reducing variable scope.*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
