### PR TITLE
Fix attention size computation error in OpenVINO backend for LLM

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -286,7 +286,7 @@ std::pair<ModelParams, ComputeParams> GgmlOvDecoder::compute_llm_params(ggml_cgr
     for (int i = 0; i < cgraph->n_nodes; i++) {
         auto * node = cgraph->nodes[i];
         std::string name = std::string(node->name);
-        if (node->op == GGML_OP_FLASH_ATTN_EXT || (node->op == GGML_OP_SOFT_MAX && node->src[1] != nullptr)) {
+        if (node->op == GGML_OP_FLASH_ATTN_EXT || (node->op == GGML_OP_SOFT_MAX && node->src[1] != nullptr && node->src[0]->src[1] != nullptr)) {
             compute_params.input_len = node->src[0]->ne[1];
 
             auto * q_perm = node->src[0];
@@ -342,6 +342,15 @@ std::pair<ModelParams, ComputeParams> GgmlOvDecoder::compute_llm_params(ggml_cgr
                 compute_params.token_len_per_seq = 1;
             }
         }
+
+        if (node->op == GGML_OP_MUL_MAT && node->src[0]->op == GGML_OP_PERMUTE &&
+            node->src[0]->src[0]->op == GGML_OP_VIEW && is_kvcache(node->src[0]->view_src, node->view_src)) {
+            if (node->src[1]->op == GGML_OP_PERMUTE && node->src[1]->src[0]->op == GGML_OP_VIEW &&
+                node->src[1]->src[0]->src[0]->op == GGML_OP_ROPE) {
+                compute_params.attention_size = node->ne[0];
+            }
+        }
+
         // if the node op is TRANSPOSE and its input is PERMUTE and the source of the PERMUTE is VIEW, then get the attention size with the TRANSPOSE node ne[0] (in case no GGML_OP_FLASH_ATTN_EXT)
         if (node->op == GGML_OP_TRANSPOSE && node->src[0]->op == GGML_OP_PERMUTE &&
             node->src[0]->src[0]->op == GGML_OP_VIEW) {

--- a/ggml/src/ggml-openvino/ggml-decoder.h
+++ b/ggml/src/ggml-openvino/ggml-decoder.h
@@ -248,8 +248,8 @@ public:
     }
 
     inline static bool is_kvcache(const ggml_tensor * tensor, const ggml_tensor * op) {
-        return (op->op == GGML_OP_SET_ROWS && op->src[2] == tensor) ||
-               tensor->buffer->usage == GGML_BACKEND_BUFFER_USAGE_ANY;
+        return tensor->buffer->usage == GGML_BACKEND_BUFFER_USAGE_ANY ||
+               (op->op == GGML_OP_SET_ROWS && op->src[2] == tensor);
     }
 
     inline static bool is_kv_idx(const ggml_tensor * tensor, const ggml_tensor * op) {

--- a/ggml/src/ggml-openvino/openvino/translate_session.cpp
+++ b/ggml/src/ggml-openvino/openvino/translate_session.cpp
@@ -146,7 +146,9 @@ void add_rope_sin_cos(TensorMap & tensor_map, GgmlDecoder & ggml_model_decoder) 
 
 // Create common patterns
 void preprocess(TensorMap & tensor_map, GgmlDecoder & ggml_model_decoder) {
-    add_sliced_mask(tensor_map, ggml_model_decoder);
+    if (ggml_model_decoder.is_stateful()) {
+        add_sliced_mask(tensor_map, ggml_model_decoder);
+    }
     add_rope_sin_cos(tensor_map, ggml_model_decoder);
 }
 


### PR DESCRIPTION
This pull request introduces several updates to the OpenVINO GGML decoder logic, primarily improving the detection and handling of attention-related operations and key-value cache identification. The changes enhance robustness when parsing computational graphs and ensure that certain preprocessing steps are only applied in appropriate contexts.

Improvements to attention and KV cache handling:

* Improved the logic in `compute_llm_params` to check for deeper source validity when handling `GGML_OP_SOFT_MAX`, preventing potential null pointer dereferences.
* Added new logic to extract `attention_size` from specific `GGML_OP_MUL_MAT` graph patterns involving permute and view operations, increasing accuracy in parameter computation for attention mechanisms.
* Refactored the `is_kvcache` static method to prioritize buffer usage checks, making the order of conditions more robust and consistent.

Preprocessing logic improvements:

* Updated the `preprocess` function to only add sliced masks when the decoder is stateful, preventing unnecessary operations for stateless models.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
