### PR TITLE
Refactor compute_llm_params() and add get_attention_pattern_case

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -297,37 +297,86 @@ int extract_layer_from_name(const std::string & name) {
 std::pair<ModelParams, ComputeParams> GgmlOvDecoder::compute_llm_params(ggml_cgraph * cgraph, bool is_static) {
     ModelParams model_params;
     ComputeParams compute_params;
+    auto get_attention_pattern_case = [](const ggml_tensor * node) -> int {
+        if (node == nullptr) {
+            return -1;
+        }
+
+        switch (node->op) {
+        case GGML_OP_FLASH_ATTN_EXT:
+            if (node->src[0] == nullptr || node->src[1] == nullptr || node->src[3] == nullptr) {
+                return -1;
+            }
+            switch (node->src[1]->op) {
+            case GGML_OP_PERMUTE:
+                // case 0: node op is FLASH_ATTN_EXT, src 1 not null & op is PERMUTE & the permuted tensor src is the view of cache k
+                if (node->src[1]->src[0] != nullptr && node->src[1]->src[0]->op == GGML_OP_VIEW) {
+                    return 0;
+                }
+                break;
+            case GGML_OP_CPY:
+                // case 1: node op is FLASH_ATTN_EXT, src 1 not null & op is CPY & the copied tensor src is PERMUTE & the permuted tensor src is the view of cache k
+                if (node->src[1]->src[0] != nullptr && node->src[1]->src[0]->op == GGML_OP_PERMUTE &&
+                    node->src[1]->src[0]->src[0] != nullptr && node->src[1]->src[0]->src[0]->op == GGML_OP_VIEW) {
+                    return 1;
+                }
+                break;
+            default:
+                break;
+            }
+            break;
+        case GGML_OP_SOFT_MAX:
+            // case 2: node op is SOFT_MAX, src 0 not null & op is MUL_MAT & the src 0 of MUL_MAT is PERMUTE & the permuted tensor src is the view of cache k
+            if (node->src[0] != nullptr && node->src[1] != nullptr && node->src[0]->op == GGML_OP_MUL_MAT &&
+                node->src[0]->src[0] != nullptr && node->src[0]->src[1] != nullptr &&
+                node->src[0]->src[0]->op == GGML_OP_PERMUTE && node->src[0]->src[0]->src[0] != nullptr &&
+                node->src[0]->src[0]->src[0]->op == GGML_OP_VIEW) {
+                return 2;
+            }
+            break;
+        default:
+            break;
+        }
+
+        return -1;
+    };
+
     for (int i = 0; i < cgraph->n_nodes; i++) {
         auto * node = cgraph->nodes[i];
         std::string name = std::string(node->name);
-        if (node->op == GGML_OP_FLASH_ATTN_EXT || (node->op == GGML_OP_SOFT_MAX && node->src[1] != nullptr && node->src[0]->src[1] != nullptr)) {
+        const int attention_pattern_case = get_attention_pattern_case(node);
+        if (attention_pattern_case != -1) {
+            ggml_tensor * cache_k_view = nullptr;
+            ggml_tensor * mask = nullptr;
+
+            switch (attention_pattern_case) {
+            case 0:
+                cache_k_view = node->src[1]->src[0];
+                mask = node->src[3];
+                break;
+            case 1:
+                cache_k_view = node->src[1]->src[0]->src[0];
+                mask = node->src[3];
+                break;
+            case 2:
+                cache_k_view = node->src[0]->src[0]->src[0];
+                mask = node->src[1];
+                break;
+            default:
+                break;
+            }
+
+            assert(cache_k_view != nullptr && mask != nullptr);
+
+            model_params.head_size = cache_k_view->ne[0];
+            model_params.n_heads_kv = cache_k_view->ne[1];
+
             compute_params.input_len = node->src[0]->ne[1];
+            compute_params.token_len_per_seq = node->ne[2];
 
-            auto * q_perm = node->src[0];
-            auto * cache_k_perm = node->src[1];
-            if (node->op == GGML_OP_SOFT_MAX) {
-                q_perm = node->src[0]->src[1];
-                cache_k_perm = node->src[0]->src[0];
-            }
-            model_params.head_size = cache_k_perm->ne[0];
-            model_params.n_heads_kv = cache_k_perm->ne[2];
-            model_params.n_heads = q_perm->ne[2];
-            compute_params.token_len_per_seq = q_perm->ne[1];
-
-            if (cache_k_perm->op == GGML_OP_CPY) {
-                cache_k_perm = cache_k_perm->src[0];
-            }
-            assert(cache_k_perm->op == GGML_OP_PERMUTE);
-            auto * cache_k_view = cache_k_perm->src[0];
-            assert(cache_k_view->op == GGML_OP_VIEW);
-
-            auto * cache_k = cache_k_view->src[0];
+            ggml_tensor * cache_k = cache_k_view->src[0];
             int layer = extract_layer_from_name(cache_k->name);
 
-            auto * mask = node->src[3];
-            if (node->op == GGML_OP_SOFT_MAX) {
-                mask = node->src[1];
-            }
             std::string mask_name(mask->name);
 
             model_params.kv_buffer_ctx_id = ggml_backend_openvino_buffer_get_ctx_id(cache_k->buffer);

--- a/ggml/src/ggml-openvino/ggml-decoder.h
+++ b/ggml/src/ggml-openvino/ggml-decoder.h
@@ -18,7 +18,6 @@ struct ModelParams {
     int ctx_per_seq = -1;
     int ctx_per_seq_swa = -1;
     int n_seq = 1;
-    int n_heads = -1;
     int n_heads_kv = -1;
     int head_size = -1;
     int32_t rope_params[15];

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -397,7 +397,7 @@ enum ggml_status ov_graph_compute_static(ggml_cgraph * cgraph, std::shared_ptr<o
         std::shared_ptr<ov::Model> model;
         auto model_weights = GgmlOvDecoder::create_weight_nodes(cgraph);
 
-        if (m_params.n_heads == -1) {
+        if (m_params.n_heads_kv == -1) {
             // graph is not a LLM, e.g. context-shift graph
             prefill_chunk_size = inp_pos->ne[0];
         }


### PR DESCRIPTION
This pull request refactors how attention pattern cases are detected and handled in the OpenVINO decoder, simplifying and making the logic more robust. It also removes the unused `n_heads` field from `ModelParams` in favor of relying solely on `n_heads_kv`, and updates related logic accordingly.

**Attention pattern handling improvements:**

* Introduced a new lambda function `get_attention_pattern_case` in `ggml-decoder.cpp` to encapsulate and clarify the detection of different attention computation patterns, replacing previous ad-hoc checks.
* Refactored the main loop in `compute_llm_params` to use the new pattern detection logic, simplifying the extraction of key parameters (`cache_k_view`, `mask`, etc.) for each case and making the code more maintainable.

**Model parameter structure and usage:**

* Removed the unused `n_heads` field from the `ModelParams` struct in `ggml-decoder.h`, consolidating head count tracking to `n_heads_kv` only.
* Updated the static graph compute logic in `utils.cpp` to check for `n_heads_kv == -1` instead of the removed `n_heads` field, ensuring correct behavior for non-LLM graphs.…ntion_pattern_case to easy extand

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
