### PR TITLE
Clean up unused code in OpenVINO backend

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -384,7 +384,6 @@ std::pair<ModelParams, ComputeParams> GgmlOvDecoder::compute_llm_params(ggml_cgr
         compute_params.output_len = 1;
     }
     model_params.ctx = model_params.ctx_per_seq * model_params.n_seq;
-    model_params.ctx_swa = model_params.ctx_per_seq_swa * model_params.n_seq;
     return {model_params, compute_params};
 }
 

--- a/ggml/src/ggml-openvino/ggml-decoder.h
+++ b/ggml/src/ggml-openvino/ggml-decoder.h
@@ -14,7 +14,6 @@
 
 struct ModelParams {
     int ctx = -1;
-    int ctx_swa = -1;
     int ctx_per_seq = -1;
     int ctx_per_seq_swa = -1;
     int n_seq = 1;
@@ -156,8 +155,6 @@ public:
     const std::map<std::string, ggml_tensor *> & get_model_outputs() const { return m_model_outputs; }
 
     virtual int get_ctx_size() const { return m_model_params.ctx; }
-
-    virtual int get_ctx_swa_size() const { return m_model_params.ctx_swa; }
 
     virtual int get_ctx_per_seq() const { return m_model_params.ctx_per_seq; }
 


### PR DESCRIPTION
This pull request removes the `ctx_swa` field and related logic from the decoder's model parameters in the OpenVINO backend. The changes simplify the `ModelParams` structure and the decoder interface by eliminating unused or unnecessary context state tracking.

Model parameter simplification:

* Removed the `ctx_swa` field from the `ModelParams` struct in `ggml-decoder.h`, as well as its initialization in the `compute_llm_params` method in `ggml-decoder.cpp`. [[1]](diffhunk://#diff-e0fb1e316593457e151c376b0c6b538e0259e3e4d255f405ad8d221240c7405dL17) [[2]](diffhunk://#diff-eafa32f3b7b0ba782711f9188ab1b9687264c80b7edf7a1d5d04c77c9ff191aeL387)
* Removed the `get_ctx_swa_size` method from the `GgmlOvDecoder` class, since the corresponding parameter no longer exists.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
