### PR TITLE
Stateless perf opt

### DIFF
--- a/ggml/src/ggml-openvino/openvino/op/flash_attn_ext.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/flash_attn_ext.cpp
@@ -73,7 +73,16 @@ OutputVector translate_flash_attn_ext(const NodeContext & context) {
     k = tile_kv(q_shape[1], k_shape[1], q_shape[3], k);
     v = tile_kv(q_shape[1], k_shape[1], q_shape[3], v);
 
-    auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(q, k, v, mask, scale_node, false);
+    ov::Output<ov::Node> sdpa_q = q;
+    int64_t factor = q_shape[1] / k_shape[1];
+    if (factor > 1 && (int64_t) k_shape[1] > 1) {
+        auto q_target_shape = ov::op::v0::Constant::create(
+            ov::element::i64, {4},
+            {(int64_t) 1, (int64_t) q_shape[1], (int64_t) -1, (int64_t) q_shape[3]});
+        sdpa_q = std::make_shared<ov::op::v1::Reshape>(q, q_target_shape, false);
+    }
+
+    auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(sdpa_q, k, v, mask, scale_node, false);
     res = std::make_shared<ov::op::v1::Transpose>(sdpa,
                                                   ov::op::v0::Constant::create(ov::element::i64, {4}, {0, 2, 1, 3}));
     res = std::make_shared<ov::op::v0::Convert>(res, ov::element::f32);

--- a/ggml/src/ggml-openvino/openvino/op/permute.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/permute.cpp
@@ -106,18 +106,26 @@ OutputVector translate_permute(const NodeContext & context) {
             auto src_reshaped = std::make_shared<ov::op::v1::Reshape>(
                 src, ov::op::v0::Constant::create(ov::element::i64, {4}, {n_seq, ctx_per_seq, n_heads, head_size}),
                 false);
-            auto slice1 =
-                std::make_shared<ov::op::v8::Slice>(src_reshaped, seq_active_start, seq_active_end, one, zero);
-            auto slice2 = std::make_shared<ov::op::v8::Slice>(slice1, zero, attention_size, one, one);
+            ov::Output<ov::Node> after_seq_slice;
+            if (n_seq == 1) {
+                after_seq_slice = src_reshaped;
+            } else {
+                after_seq_slice = std::make_shared<ov::op::v8::Slice>(src_reshaped, seq_active_start, seq_active_end, one, zero);
+            }
+            auto slice2 = std::make_shared<ov::op::v8::Slice>(after_seq_slice, zero, attention_size, one, one);
             res = std::make_shared<ov::op::v1::Transpose>(slice2, perm);
         } else {
             auto three = ov::op::v0::Constant::create(ov::element::i64, {1}, {3});
             auto src_reshaped = std::make_shared<ov::op::v1::Reshape>(
                 src, ov::op::v0::Constant::create(ov::element::i64, {4}, {n_seq, n_heads, head_size, ctx_per_seq}),
                 false);
-            auto slice1 =
-                std::make_shared<ov::op::v8::Slice>(src_reshaped, seq_active_start, seq_active_end, one, zero);
-            auto slice2 = std::make_shared<ov::op::v8::Slice>(slice1, zero, attention_size, one, three);
+            ov::Output<ov::Node> after_seq_slice;
+            if (n_seq == 1) {
+                after_seq_slice = src_reshaped;
+            } else {
+                after_seq_slice = std::make_shared<ov::op::v8::Slice>(src_reshaped, seq_active_start, seq_active_end, one, zero);
+            }
+            auto slice2 = std::make_shared<ov::op::v8::Slice>(after_seq_slice, zero, attention_size, one, three);
             res = slice2;
         }
     }


### PR DESCRIPTION
- flash_attn_ext, gated to GQA models: fixed the Qwen stateless correctness bug that made prior baselines meaningless, and delivered 13-39% PP / 22-34% TG speedups on Llama and Qwen.
- permute, gated to n_seq == 1: +5-7% TG on GQA models by eliminating identity v8::Slice ops in the attention path.

Note: This PR is created based on recent experiments with claude AI.