### PR TITLE
Fix CPY support for non-contiguous data and mismatched types in OpenVINO backend

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -859,8 +859,8 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         break;
     }
     case GGML_OP_CPY: {
-        if (op->src[1] != op) {
-            // GGML_LOG_WARN("OpenVINO backend only supports CPY that is a cast\n");
+        if (!ggml_is_contiguous(op->src[0]) || !ggml_is_contiguous(op->src[1]) || op->src[0]->type != op->src[1]->type) {
+            // GGML_LOG_WARN("OpenVINO backend does not support CPY with non-contiguous data or mismatched types\n");
             return true;
         }
         break;


### PR DESCRIPTION
This pull request updates the logic for determining unsupported cases in the OpenVINO backend's handling of the `CPY` operation. The new logic adds stricter checks to ensure both source tensors are contiguous and of the same type before allowing the operation.

**Improved validation for `CPY` operation support:**

* Updated `is_op_unsupported_case` in `ggml-openvino.cpp` to check that both `op->src[0]` and `op->src[1]` are contiguous and have matching types before marking the operation as supported. This prevents unsupported cases where data layout or type mismatches could cause issues.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
[Copilot is generating a summary...]