### PR TITLE
Fix issue in mul_mat_id for OpenVINO backend

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -807,6 +807,17 @@ std::shared_ptr<ov::Node> GgmlOvDecoder::create_weight_node(ggml_tensor * tensor
         }
     }
 
+    // MUL_MAT_ID expert weights are 3D GGML tensors [k, m, n_expert].
+    // Keep the full reversed 4D shape when materializing non-quantized constants,
+    // otherwise the expert dimension is collapsed and later Gather/MatMul logic
+    // only sees a single expert slice.
+    if (!ggml_is_quantized(tensor->type) && (tensor->ne[2] > 1 || tensor->ne[3] > 1)) {
+        auto weight_tensor = ov::Tensor(get_ov_type(tensor), get_shape(tensor), tensor->data);
+        auto weight_node = std::make_shared<ov::op::v0::Constant>(weight_tensor);
+        weight_node->set_friendly_name(tensor->name);
+        return weight_node;
+    }
+
     // There are three cases where we need to create a new weight node:
     // 1. weights are in openvino_host_buffer. Weight loading to host buffer will not trigger backend_buffer_set_tensor
     // 2. weights are in cpu/cpu_mapped buffer. On token_embd.weight goes to case 1 or 2, depending on whether mmap or direct_io is used

--- a/ggml/src/ggml-openvino/openvino/op/mul_mat_id.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/mul_mat_id.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <openvino/op/broadcast.hpp>
+#include <openvino/op/concat.hpp>
 #include <openvino/op/constant.hpp>
 #include <openvino/op/convert.hpp>
 #include <openvino/op/gather.hpp>
@@ -29,13 +30,20 @@ OutputVector translate_mul_mat_id(const NodeContext & context) {
     //   weights: [1, n_expert, m, k]
     //   activations: [1, n_tokens, n_used_or_1, k]
     //   ids: [1, 1, n_tokens, n_used]
-    auto squeeze_weights_axes = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
-    auto squeeze_acts_axes = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
-    auto squeeze_ids_axes = ov::op::v0::Constant::create(ov::element::i64, {2}, {0, 1});
+    // Rebuild the logical ranks explicitly from the 4D inputs instead of relying
+    // on fixed squeeze axes: real graphs can arrive through VIEW/RESHAPE chains
+    // where singleton axes are still represented differently at this point.
+    auto expert_weights_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(expert_weights, ov::element::i64);
+    auto activations_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(activations, ov::element::i64);
+    auto ids_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(ids, ov::element::i64);
 
-    expert_weights = std::make_shared<ov::op::v0::Squeeze>(expert_weights, squeeze_weights_axes);
-    activations = std::make_shared<ov::op::v0::Squeeze>(activations, squeeze_acts_axes);
-    ids = std::make_shared<ov::op::v0::Squeeze>(ids, squeeze_ids_axes);
+    auto expert_weights_shape_3d = get_dimensions(expert_weights_shape_4d, {1, 2, 3});
+    auto activations_shape_3d = get_dimensions(activations_shape_4d, {1, 2, 3});
+    auto ids_shape_2d = get_dimensions(ids_shape_4d, {2, 3});
+
+    expert_weights = std::make_shared<ov::op::v1::Reshape>(expert_weights, expert_weights_shape_3d, false);
+    activations = std::make_shared<ov::op::v1::Reshape>(activations, activations_shape_3d, false);
+    ids = std::make_shared<ov::op::v1::Reshape>(ids, ids_shape_2d, false);
 
     if (ids.get_element_type() != ov::element::i32 && ids.get_element_type() != ov::element::i64) {
         ids = std::make_shared<ov::op::v0::Convert>(ids, ov::element::i32);
@@ -52,19 +60,41 @@ OutputVector translate_mul_mat_id(const NodeContext & context) {
         activations = std::make_shared<ov::op::v0::Convert>(activations, ov::element::f32);
     }
 
-    auto selected_weights_shape = std::make_shared<ov::op::v3::ShapeOf>(selected_weights, ov::element::i64);
-    auto acts_target_dims = get_dimensions(selected_weights_shape, {0, 1, 3});
+    auto activations_shape = std::make_shared<ov::op::v3::ShapeOf>(activations, ov::element::i64);
+    auto ids_shape = std::make_shared<ov::op::v3::ShapeOf>(ids, ov::element::i64);
+    ov::Output<ov::Node> acts_target_dims = std::make_shared<ov::op::v0::Concat>(
+        ov::OutputVector{
+            get_dimensions(activations_shape, {0}),
+            get_dimensions(ids_shape, {1}),
+            get_dimensions(activations_shape, {2}),
+        },
+        0);
     ov::Output<ov::Node> acts_broadcasted = std::make_shared<ov::op::v3::Broadcast>(activations, acts_target_dims,
                                                                                      ov::op::BroadcastType::BIDIRECTIONAL);
 
     auto unsqueeze_axes = ov::op::v0::Constant::create(ov::element::i64, {1}, {2});
     auto activations_expanded = std::make_shared<ov::op::v0::Unsqueeze>(acts_broadcasted, unsqueeze_axes);
 
-    ov::Output<ov::Node> result = std::make_shared<ov::op::v0::MatMul>(activations_expanded, selected_weights, false, true);
-    result = std::make_shared<ov::op::v0::Squeeze>(result, unsqueeze_axes);
+    auto batch_dim = ov::op::v0::Constant::create(ov::element::i64, {1}, {1});
+    auto output_shape = context.get_output_shape();
+    FRONT_END_OP_CONVERSION_CHECK(output_shape.rank().is_static() && output_shape.rank().get_length() == 4,
+                                  "Unexpected MUL_MAT_ID output rank");
+    FRONT_END_OP_CONVERSION_CHECK(output_shape[3].is_static(),
+                                  "Expected static row dimension for MUL_MAT_ID output");
+    const auto row_dim_value = output_shape[3].get_length();
+    auto row_dim = ov::op::v0::Constant::create(ov::element::i64, {1}, {row_dim_value});
 
-    auto restore_batch_axis = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
-    result = std::make_shared<ov::op::v0::Unsqueeze>(result, restore_batch_axis);
+    ov::Output<ov::Node> result =
+        std::make_shared<ov::op::v0::MatMul>(activations_expanded, selected_weights, false, true);
+
+    auto result_target_dims = std::make_shared<ov::op::v0::Concat>(
+        ov::OutputVector{
+            batch_dim,
+            get_dimensions(ids_shape, {0, 1}),
+            row_dim,
+        },
+        0);
+    result = std::make_shared<ov::op::v1::Reshape>(result, result_target_dims, false);
 
     if (result.get_element_type() != output_type) {
         result = std::make_shared<ov::op::v0::Convert>(result, output_type);


### PR DESCRIPTION
This pull request refines the handling and shape management of expert weights and activations in the OpenVINO backend for the `MUL_MAT_ID` operation. The core improvements ensure that multi-expert weight tensors retain their full dimensionality, and that input/output tensor shapes are rebuilt more robustly, improving compatibility with dynamic or reshaped input graphs.

Key changes include:

**Shape Handling and Tensor Materialization:**

* In `ggml-decoder.cpp`, when materializing non-quantized expert weights, the code now preserves the full reversed 4D shape, ensuring that the expert dimension is not collapsed. This prevents issues where later operations (like Gather/MatMul) would only see a single expert slice.

**Dynamic Shape Reconstruction and Reshaping:**

* In `mul_mat_id.cpp`, the logic for squeezing singleton axes from weights, activations, and ids is replaced with explicit dynamic shape reconstruction using `ShapeOf` and `Reshape`. This makes the code robust to input tensors that may have undergone reshaping or view operations, ensuring correct logical ranks regardless of input shape permutations.
* The output shape of the `MatMul` result is now explicitly constructed using dynamic shape information and the expected output rank, replacing previous fixed unsqueeze/squeeze logic. This ensures that the output tensor always matches the required 4D shape, with checks for static rank and row dimension.

**General Improvements:**

* Added missing include for `concat.hpp` to support new shape concatenation logic.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
