### PR TITLE
Disable DIV with broadcast on OpenVINO GPU backend

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -1436,10 +1436,11 @@ void GgmlOvDecoder::compute_node_dynamic_dims() {
                         break;
                     }
                 }
-                OPENVINO_ASSERT(m_node_dynamic_dims[node] != -1 &&
-                                dynamic_dim_value == node->ne[m_node_dynamic_dims[node]],
-                                "Dynamic dim value mismatch for node: " + std::string(node->name) +
-                                    " and its src[0]: " + std::string(node->src[0]->name));
+                if (m_node_dynamic_dims[node] != -1 && dynamic_dim_value != node->ne[m_node_dynamic_dims[node]]) {
+                    m_node_dynamic_dims[node] = -1;
+                    std::cout << "Warning: Dynamic dim value mismatch for node: " << node->name
+                              << " and its src[0]: " << node->src[0]->name << std::endl;
+                }
             }
             break;
         }
@@ -1513,9 +1514,11 @@ void GgmlOvDecoder::compute_node_dynamic_dims() {
                             matched_dim_count++;
                         }
                     }
-
-                    OPENVINO_ASSERT(matched_dim_count == 1,
-                                    "Cannot determine dynamic dim for CONT node: " + std::string(node->name));
+                    if (matched_dim_count != 1) {
+                        m_node_dynamic_dims[node] = -1;
+                        std::cout << "Warning: Cannot determine dynamic dim for CONT node: " << node->name
+                                  << " and its src[0]: " << node->src[0]->name << std::endl;
+                    }
                 }
             }
             break;

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -873,6 +873,28 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         }
         break;
     }
+    case GGML_OP_DIV: {
+        bool requires_broadcast = false;
+        for (int i = 0; i < 4; i++) {
+            if (op->src[0]->ne[i] == op->src[1]->ne[i]) {
+                continue;
+            }
+
+            if (op->src[0]->ne[i] != 1 && op->src[1]->ne[i] != 1) {
+                return true;
+            }
+
+            requires_broadcast = true;
+        }
+
+        // The GPU plugin can fuse broadcast DIV into the preceding FFN GEMM path
+        // and produce infs for per-channel scale vectors. Keep those DIVs on CPU
+        // until the fused GPU kernel is reliable. (falied case llama-arch-test mpt)
+        if (requires_broadcast && ggml_openvino_get_device_name() == "GPU") {
+            return true;
+        }
+        break;
+    }
     case GGML_OP_SOFT_MAX: {
         if (op->src[2] != nullptr) {
             // GGML_LOG_WARN("OpenVINO backend does not support SOFT_MAX with sinks\n");


### PR DESCRIPTION
This pull request makes targeted improvements to the dynamic dimension handling and operator support logic in the OpenVINO backend of the codebase. The main changes focus on making error handling more robust in the decoder and adding better support for division operations, especially when broadcasting is involved on GPU devices.

**Dynamic dimension handling improvements:**

* Replaced assertions with warnings in `GgmlOvDecoder::compute_node_dynamic_dims()` to prevent hard failures when dynamic dimension mismatches are detected, instead setting the dynamic dimension to `-1` and logging a warning.
* Added a warning and fallback for cases where the dynamic dimension for a CONT node cannot be uniquely determined, instead of asserting and halting execution.

**Operator support enhancements:**

* Updated `is_op_unsupported_case()` to mark division operations (`GGML_OP_DIV`) as unsupported when broadcasting is required and the device is GPU, due to known issues with fused GPU kernels producing invalid results. This prevents problematic DIV operations from running on GPU until the kernel is reliable.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
