### PR TITLE
Clean unused code and fix build warnings in OpenVINO backend

### DIFF
--- a/ggml/src/ggml-openvino/openvino/op/gated_delta_net.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/gated_delta_net.cpp
@@ -31,9 +31,6 @@ namespace op {
 OutputVector translate_gated_delta_net(const NodeContext & context) {
     auto v_shape = context.get_input_shape(2).to_shape();  // [B, T, H_v, S_v]
     auto q_shape = context.get_input_shape(0).to_shape();  // [B, T, H_k, S_k]
-    auto g_shape = context.get_input_shape(3).to_shape();  // [B, T, H_v, 1 or S_v]
-
-    const bool kda = (g_shape[3] == v_shape[3]);
 
     // Fused GatedDeltaNet op only supports scalar gate (kda=0).
     // Fall back to reference implementation for per-key-dimension gating.
@@ -52,7 +49,6 @@ OutputVector translate_gated_delta_net(const NodeContext & context) {
     const int64_t T = v_shape[1];
     const int64_t H_v = v_shape[2];
     const int64_t S_v = v_shape[3];
-    const int64_t H_k = q_shape[2];
     const int64_t S_k = q_shape[3];
 
     // ggml state layout (OV notation): [B, H_v, value_dim, key_dim]
@@ -83,7 +79,7 @@ OutputVector translate_gated_delta_net(const NodeContext & context) {
     return rename_outputs_with_suffix({res}, context.get_name());
 }
 
-OutputVector translate_gated_delta_net_ref(const NodeContext & context) {
+static OutputVector translate_gated_delta_net_ref(const NodeContext & context) {
     num_inputs_check(context, 6, 6);
 
     // Inputs (OV shapes are reversed from ggml):


### PR DESCRIPTION
This pull request makes minor refactoring and code cleanup changes to the `translate_gated_delta_net` and related functions in `ggml-openvino`. The changes remove an unused variable, make a function `static`, and clean up some variable declarations.

Code cleanup and refactoring:

* Removed the unused `g_shape` and `kda` variables from `translate_gated_delta_net`, as the per-key-dimension gating logic is not supported in the fused op.
* Removed the unused `H_k` variable from `translate_gated_delta_net`.
* Made the `translate_gated_delta_net_ref` function `static` to limit its visibility to the current translation unit.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
