### PR TITLE
Enable minicpm3 for OpenVINO backend architecture tests

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -463,6 +463,10 @@ std::pair<ModelParams, ComputeParams> GgmlOvDecoder::compute_llm_params(ggml_cgr
             }
         }
         if (node->op == GGML_OP_ROPE) {
+            if (compute_params.token_len_per_seq == -1 && node->src[1] != nullptr) {
+                compute_params.token_len_per_seq = ggml_nelements(node->src[1]);
+            }
+
             // When multiple ROPE ops in the graph disagree on op_params (e.g. gemma4's
             // mixed SWA/non-SWA layers with different n_dims or freq_base), we cannot
             // share a single precomputed rope_sin/rope_cos. Track divergence so the
@@ -578,14 +582,18 @@ void GgmlOvDecoder::add_extra_inputs() {
         }
     };
 
-    create_1d_input("attention_size", m_compute_params.attention_size);
+    if (m_compute_params.attention_size != -1) {
+        create_1d_input("attention_size", m_compute_params.attention_size);
+    }
     if (m_compute_params.attention_size_swa != -1) {
         create_1d_input("attention_size_swa", m_compute_params.attention_size_swa);
     }
     create_1d_input("n_seq_active", m_compute_params.n_seq_active);
     create_1d_input("seq_active_start", m_compute_params.seq_active_start);
     create_1d_input("seq_active_end", m_compute_params.seq_active_start + m_compute_params.n_seq_active);
-    create_1d_input("token_len_per_seq", m_compute_params.token_len_per_seq);
+    if (m_compute_params.token_len_per_seq != -1) {
+        create_1d_input("token_len_per_seq", m_compute_params.token_len_per_seq);
+    }
     // create_1d_input("token_len", m_token_len_per_seq * m_n_seq_active);
 }
 


### PR DESCRIPTION
This pull request introduces improvements to how sequence and attention parameters are handled in the OpenVINO decoder implementation. The main focus is on ensuring that parameters such as `token_len_per_seq` and `attention_size` are correctly set and passed as inputs when available.

Parameter handling improvements:

* In `compute_llm_params`, the `token_len_per_seq` parameter is now set based on the size of `node->src[1]` if it hasn't been set yet and the source exists. This ensures accurate tracking of token lengths for each sequence.
* In `add_extra_inputs`, both `attention_size` and `token_len_per_seq` are now only added as extra inputs if their values are set (not equal to -1), preventing the creation of unnecessary or invalid inputs.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
