### PR TITLE
Stateless broadcast optimization

### DIFF
--- a/ggml/src/ggml-openvino/openvino/op/flash_attn_ext.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/flash_attn_ext.cpp
@@ -4,12 +4,16 @@
 
 #include <cstdint>
 #include <memory>
+#include <openvino/op/add.hpp>
 #include <openvino/op/broadcast.hpp>
 #include <openvino/op/concat.hpp>
 #include <openvino/op/constant.hpp>
 #include <openvino/op/convert.hpp>
+#include <openvino/op/matmul.hpp>
+#include <openvino/op/multiply.hpp>
 #include <openvino/op/reshape.hpp>
 #include <openvino/op/scaled_dot_product_attention.hpp>
+#include <openvino/op/softmax.hpp>
 #include <openvino/op/transpose.hpp>
 #include <openvino/op/unsqueeze.hpp>
 #include <string>
@@ -49,17 +53,93 @@ OutputVector translate_flash_attn_ext(const NodeContext & context) {
         mask = std::make_shared<ov::op::v0::Convert>(mask, ov::element::f16);
     }
 
-    auto tile_kv = [&](int64_t num_heads, int64_t num_heads_kv, int64_t head_size, ov::Output<Node> kv) {
-        int64_t factor = num_heads / num_heads_kv;
-        if (factor > 1 && num_heads_kv > 1) {
+    //auto tile_kv = [&](int64_t num_heads, int64_t num_heads_kv, int64_t head_size, ov::Output<Node> kv) {
+    //    int64_t factor = num_heads / num_heads_kv;
+    //    if (factor > 1 && num_heads_kv > 1) {
+    auto q_shape = context.get_input_shape(0).to_shape();
+    auto k_shape = context.get_input_shape(1).to_shape();
+    const int64_t num_heads     = q_shape[1];
+    const int64_t num_heads_kv  = k_shape[1];
+    const int64_t head_size     = q_shape[3];
+    const int64_t factor        = num_heads / num_heads_kv;
+
+    // Optional path: skip the explicit Broadcast that materialises K and V at
+    // num_heads. Express attention manually so MatMul's NUMPY-broadcast handles
+    // the GQA expansion at kernel level (K and V are read once from DRAM).
+    // Opt in with GGML_OPENVINO_MANUAL_GQA_ATTN=1.
+    static const bool manual_gqa_enabled = getenv("GGML_OPENVINO_MANUAL_GQA_ATTN") != nullptr;
+    const bool use_manual_gqa_attention =
+        manual_gqa_enabled && factor > 1 && num_heads_kv > 1 && !context.is_stateful();
+
+    if (use_manual_gqa_attention) {
+        // K, V arrive as [1, num_heads_kv, S, head_size]. Reshape to
+        //   K_r: [1, num_heads_kv, 1, S, head_size]
+        //   Q_r: [1, num_heads_kv, factor, S_q, head_size]
+        // and let MatMul broadcast across the factor dim without materialising
+        // an expanded K/V.
+        auto k_5d_shape = ov::op::v0::Constant::create(
+            ov::element::i64, {5},
+            std::vector<int64_t>{1, num_heads_kv, 1, -1, head_size});
+        auto v_5d_shape = ov::op::v0::Constant::create(
+            ov::element::i64, {5},
+            std::vector<int64_t>{1, num_heads_kv, 1, -1, head_size});
+        auto q_5d_shape = ov::op::v0::Constant::create(
+            ov::element::i64, {5},
+            std::vector<int64_t>{1, num_heads_kv, factor, -1, head_size});
+
+        auto k_r = std::make_shared<ov::op::v1::Reshape>(k, k_5d_shape, false);
+        auto v_r = std::make_shared<ov::op::v1::Reshape>(v, v_5d_shape, false);
+        auto q_r = std::make_shared<ov::op::v1::Reshape>(q, q_5d_shape, false);
+
+        // QK^T → [1, num_heads_kv, factor, S_q, S_k]
+        auto qk = std::make_shared<ov::op::v0::MatMul>(q_r, k_r, /*tA=*/false, /*tB=*/true);
+        auto qk_scaled = std::make_shared<ov::op::v1::Multiply>(qk, scale_node);
+
+        // Mask shape is [B, 1, S_q, S_k] in stateless. We need to broadcast it to
+        // [1, num_heads_kv, factor, S_q, S_k]. NUMPY broadcast on Add will handle
+        // the trailing dims if we Unsqueeze the mask twice on the leading head
+        // dimensions to bring it to rank 5.
+        auto mask_unsq1 = std::make_shared<ov::op::v0::Unsqueeze>(
+            mask, ov::op::v0::Constant::create(ov::element::i64, {1}, {0}));
+        // mask_unsq1: [1, B, 1, S_q, S_k] (rank 5)
+        ov::Output<ov::Node> qk_masked = std::make_shared<ov::op::v1::Add>(qk_scaled, mask_unsq1);
+
+        auto softmax = std::make_shared<ov::op::v8::Softmax>(qk_masked, /*axis=*/-1);
+
+        // softmax @ V → [1, num_heads_kv, factor, S_q, head_size]
+        auto attn = std::make_shared<ov::op::v0::MatMul>(softmax, v_r);
+
+        // Reshape back to [1, num_heads, S_q, head_size] (combine num_heads_kv * factor).
+        auto out_4d_shape = ov::op::v0::Constant::create(
+            ov::element::i64, {4},
+            std::vector<int64_t>{1, num_heads, -1, head_size});
+        auto out_4d = std::make_shared<ov::op::v1::Reshape>(attn, out_4d_shape, false);
+
+        // The standard SDPA path's downstream is Transpose(0,2,1,3) → Convert(f32).
+        // Replicate it here so callers see the same output layout/dtype.
+        res = std::make_shared<ov::op::v1::Transpose>(
+            out_4d, ov::op::v0::Constant::create(ov::element::i64, {4}, {0, 2, 1, 3}));
+        res = std::make_shared<ov::op::v0::Convert>(res, ov::element::f32);
+        return rename_outputs_with_suffix({res}, context.get_name());
+    }
+
+    // Default path: explicit Broadcast → SDPA. Kept as the fallback because
+    // (a) it goes through the GPU plugin's micro-SDPA fast path (FlashAttention
+    // tiles via DPAS), and (b) the manual path above is still being validated.
+    auto tile_kv = [&](int64_t n_heads, int64_t n_heads_kv, int64_t hs, ov::Output<Node> kv) {
+        int64_t f = n_heads / n_heads_kv;
+        if (f > 1 && n_heads_kv > 1) {
             ov::Output<ov::Node> kv_broadcast_shape, kv_unsqueezed, new_kv_shape;
             auto unsqueeze_axes = ov::op::v0::Constant::create(ov::element::i64, Shape{}, {2});
             kv_unsqueezed = std::make_shared<ov::op::v0::Unsqueeze>(kv, unsqueeze_axes);
 
             kv_broadcast_shape = ov::op::v0::Constant::create(
-                ov::element::i64, {5}, {(int64_t) 1, (int64_t) 1, factor, (int64_t) 1, (int64_t) 1});
+                ov::element::i64, {5}, {(int64_t) 1, (int64_t) 1, f, (int64_t) 1, (int64_t) 1});
             new_kv_shape =
-                ov::op::v0::Constant::create(ov::element::i64, {4}, {(int64_t) 0, num_heads, (int64_t) -1, head_size});
+                ov::op::v0::Constant::create(ov::element::i64, {4}, {(int64_t) 0, n_heads, (int64_t) -1, hs});
+            //    ov::element::i64, {5}, {(int64_t) 1, (int64_t) 1, factor, (int64_t) 1, (int64_t) 1});
+            //new_kv_shape =
+            //    ov::op::v0::Constant::create(ov::element::i64, {4}, {(int64_t) 0, num_heads, (int64_t) -1, head_size});
 
             kv = std::make_shared<ov::op::v3::Broadcast>(kv_unsqueezed, kv_broadcast_shape,
                                                          ov::op::BroadcastType::BIDIRECTIONAL);
@@ -68,10 +148,12 @@ OutputVector translate_flash_attn_ext(const NodeContext & context) {
         return kv;
     };
 
-    auto q_shape = context.get_input_shape(0).to_shape();
-    auto k_shape = context.get_input_shape(1).to_shape();
-    k = tile_kv(q_shape[1], k_shape[1], q_shape[3], k);
-    v = tile_kv(q_shape[1], k_shape[1], q_shape[3], v);
+    //auto q_shape = context.get_input_shape(0).to_shape();
+    //auto k_shape = context.get_input_shape(1).to_shape();
+    //k = tile_kv(q_shape[1], k_shape[1], q_shape[3], k);
+    //v = tile_kv(q_shape[1], k_shape[1], q_shape[3], v);
+    k = tile_kv(num_heads, num_heads_kv, head_size, k);
+    v = tile_kv(num_heads, num_heads_kv, head_size, v);
 
     auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(q, k, v, mask, scale_node, false);
     res = std::make_shared<ov::op::v1::Transpose>(sdpa,

--- a/ggml/src/ggml-openvino/openvino/op/flash_attn_ext.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/flash_attn_ext.cpp
@@ -3,6 +3,7 @@
 #include "../utils.h"
 
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <openvino/op/add.hpp>
 #include <openvino/op/broadcast.hpp>
@@ -63,11 +64,16 @@ OutputVector translate_flash_attn_ext(const NodeContext & context) {
     const int64_t head_size     = q_shape[3];
     const int64_t factor        = num_heads / num_heads_kv;
 
-    // Optional path: skip the explicit Broadcast that materialises K and V at
-    // num_heads. Express attention manually so MatMul's NUMPY-broadcast handles
-    // the GQA expansion at kernel level (K and V are read once from DRAM).
-    // Opt in with GGML_OPENVINO_MANUAL_GQA_ATTN=1.
-    static const bool manual_gqa_enabled = getenv("GGML_OPENVINO_MANUAL_GQA_ATTN") != nullptr;
+    // Manual GQA attention: enabled by default on GPU in stateless mode.
+    // Set GGML_OPENVINO_MANUAL_GQA_ATTN=0 to explicitly disable.
+    static const bool manual_gqa_enabled = []() {
+        const char * env = getenv("GGML_OPENVINO_MANUAL_GQA_ATTN");
+        if (env != nullptr) {
+            return std::string(env) != "0";
+        }
+        const char * dev = getenv("GGML_OPENVINO_DEVICE");
+        return dev != nullptr && std::string(dev) == "GPU";
+    }();
     const bool use_manual_gqa_attention =
         manual_gqa_enabled && factor > 1 && num_heads_kv > 1 && !context.is_stateful();
 

--- a/ggml/src/ggml-openvino/openvino/op/flash_attn_ext.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/flash_attn_ext.cpp
@@ -78,48 +78,53 @@ OutputVector translate_flash_attn_ext(const NodeContext & context) {
         manual_gqa_enabled && factor > 1 && num_heads_kv > 1 && !context.is_stateful();
 
     if (use_manual_gqa_attention) {
-        // K, V arrive as [1, num_heads_kv, S, head_size]. Reshape to
-        //   K_r: [1, num_heads_kv, 1, S, head_size]
-        //   Q_r: [1, num_heads_kv, factor, S_q, head_size]
+        // Q, K, V arrive as [B, n_heads(_kv), S, head_size], where B is the active
+        // batch (n_seq_active) and may be > 1 (llama-perplexity, llama-server -np > 1)
+        // or dynamic. Reshape to
+        //   K_r: [B, num_heads_kv, 1, S, head_size]
+        //   Q_r: [B, num_heads_kv, factor, S_q, head_size]
         // and let MatMul broadcast across the factor dim without materialising
-        // an expanded K/V.
+        // an expanded K/V. The leading 0 + special_zero=true copies B at runtime,
+        // so this is correct for B == 1, B > 1, and dynamic B alike. Only the head
+        // dims and head_size are baked in as literals; the sequence dim stays -1.
         auto k_5d_shape = ov::op::v0::Constant::create(
             ov::element::i64, {5},
-            std::vector<int64_t>{1, num_heads_kv, 1, -1, head_size});
+            std::vector<int64_t>{0, num_heads_kv, 1, -1, head_size});
         auto v_5d_shape = ov::op::v0::Constant::create(
             ov::element::i64, {5},
-            std::vector<int64_t>{1, num_heads_kv, 1, -1, head_size});
+            std::vector<int64_t>{0, num_heads_kv, 1, -1, head_size});
         auto q_5d_shape = ov::op::v0::Constant::create(
             ov::element::i64, {5},
-            std::vector<int64_t>{1, num_heads_kv, factor, -1, head_size});
+            std::vector<int64_t>{0, num_heads_kv, factor, -1, head_size});
 
-        auto k_r = std::make_shared<ov::op::v1::Reshape>(k, k_5d_shape, false);
-        auto v_r = std::make_shared<ov::op::v1::Reshape>(v, v_5d_shape, false);
-        auto q_r = std::make_shared<ov::op::v1::Reshape>(q, q_5d_shape, false);
+        auto k_r = std::make_shared<ov::op::v1::Reshape>(k, k_5d_shape, true);
+        auto v_r = std::make_shared<ov::op::v1::Reshape>(v, v_5d_shape, true);
+        auto q_r = std::make_shared<ov::op::v1::Reshape>(q, q_5d_shape, true);
 
-        // QK^T → [1, num_heads_kv, factor, S_q, S_k]
+        // QK^T → [B, num_heads_kv, factor, S_q, S_k]
         auto qk = std::make_shared<ov::op::v0::MatMul>(q_r, k_r, /*tA=*/false, /*tB=*/true);
         auto qk_scaled = std::make_shared<ov::op::v1::Multiply>(qk, scale_node);
 
-        // Mask shape is [B, 1, S_q, S_k] in stateless. We need to broadcast it to
-        // [1, num_heads_kv, factor, S_q, S_k]. NUMPY broadcast on Add will handle
-        // the trailing dims if we Unsqueeze the mask twice on the leading head
-        // dimensions to bring it to rank 5.
+        // Mask arrives as [B, 1, S_q, S_k]. Unsqueeze a factor axis at position 2 to
+        // get [B, 1, 1, S_q, S_k], which NUMPY-broadcasts cleanly against the
+        // [B, num_heads_kv, factor, S_q, S_k] scores: B==B, then 1→num_heads_kv and
+        // 1→factor on the head dims.
         auto mask_unsq1 = std::make_shared<ov::op::v0::Unsqueeze>(
-            mask, ov::op::v0::Constant::create(ov::element::i64, {1}, {0}));
-        // mask_unsq1: [1, B, 1, S_q, S_k] (rank 5)
+            mask, ov::op::v0::Constant::create(ov::element::i64, {1}, {2}));
+        // mask_unsq1: [B, 1, 1, S_q, S_k] (rank 5)
         ov::Output<ov::Node> qk_masked = std::make_shared<ov::op::v1::Add>(qk_scaled, mask_unsq1);
 
         auto softmax = std::make_shared<ov::op::v8::Softmax>(qk_masked, /*axis=*/-1);
 
-        // softmax @ V → [1, num_heads_kv, factor, S_q, head_size]
+        // softmax @ V → [B, num_heads_kv, factor, S_q, head_size]
         auto attn = std::make_shared<ov::op::v0::MatMul>(softmax, v_r);
 
-        // Reshape back to [1, num_heads, S_q, head_size] (combine num_heads_kv * factor).
+        // Reshape back to [B, num_heads, S_q, head_size] (combine num_heads_kv * factor).
+        // Leading 0 + special_zero=true copies B at runtime.
         auto out_4d_shape = ov::op::v0::Constant::create(
             ov::element::i64, {4},
-            std::vector<int64_t>{1, num_heads, -1, head_size});
-        auto out_4d = std::make_shared<ov::op::v1::Reshape>(attn, out_4d_shape, false);
+            std::vector<int64_t>{0, num_heads, -1, head_size});
+        auto out_4d = std::make_shared<ov::op::v1::Reshape>(attn, out_4d_shape, true);
 
         // The standard SDPA path's downstream is Transpose(0,2,1,3) → Convert(f32).
         // Replicate it here so callers see the same output layout/dtype.

--- a/ggml/src/ggml-openvino/openvino/op/rope.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/rope.cpp
@@ -7,6 +7,7 @@
 #include <openvino/core/node.hpp>
 #include <openvino/core/node_output.hpp>
 #include <openvino/op/add.hpp>
+#include <openvino/op/broadcast.hpp>
 #include <openvino/op/concat.hpp>
 #include <openvino/op/constant.hpp>
 #include <openvino/op/convert.hpp>
@@ -87,7 +88,66 @@ OutputVector translate_rope(const NodeContext & context) {
         data_node = std::make_shared<ov::op::v0::Convert>(data_node, ov::element::f32);
     }
 
-    if (mode == TYPE_NORMAL) {
+    //if (mode == TYPE_NORMAL) {
+    if (mode == TYPE_NORMAL && !context.is_stateful()) {
+        // Stateless rank-4 path. Emit the Flux-style interleaved-RoPE pattern so the
+        // GPU plugin's RoPEFusionFlux matcher folds this subgraph into
+        // ov::op::internal::RoPE:
+        //   x_paired   = Reshape(x, [1, S, n_heads, head_size/2, 2])
+        //   x0, x1     = Split(x_paired, axis=-1, num_splits=2)
+        //   x1_neg     = x1 * -1
+        //   x_rotated  = Reshape(Concat([x1_neg, x0], axis=-1), [1, S, n_heads, head_size])
+        //   y          = x * t_cos + x_rotated * t_sin
+        // Mathematically equivalent to the previous even/odd Slice form.
+        const int64_t head_size = static_cast<int64_t>(output_shape[3]);
+        const int64_t n_heads   = static_cast<int64_t>(output_shape[2]);
+        const int64_t half      = head_size / 2;
+
+        auto neg_one_f = ov::op::v0::Constant::create(data_node->get_element_type(), ov::Shape{}, {-1.0f});
+
+        auto paired_shape = ov::op::v0::Constant::create(
+            ov::element::i64, {5}, std::vector<int64_t>{1, -1, n_heads, half, 2});
+        auto x_paired = std::make_shared<ov::op::v1::Reshape>(data_node, paired_shape, false);
+
+        auto split_axis = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {-1});
+        auto data_split = std::make_shared<ov::op::v1::Split>(x_paired, split_axis, 2);
+        Output<Node> x0 = data_split->outputs()[0];
+        Output<Node> x1 = data_split->outputs()[1];
+
+        auto x1_neg = std::make_shared<ov::op::v1::Multiply>(x1, neg_one_f);
+        auto x_rotated_paired =
+            std::make_shared<ov::op::v0::Concat>(ov::OutputVector{x1_neg, x0}, -1);
+
+        auto flat_shape = ov::op::v0::Constant::create(
+            ov::element::i64, {4}, std::vector<int64_t>{1, -1, n_heads, head_size});
+        auto x_rotated =
+            std::make_shared<ov::op::v1::Reshape>(x_rotated_paired, flat_shape, false);
+
+        // Expand cos/sin from [..., head_size/2] to [..., head_size] by repeating each
+        // entry twice. Use special_zero on the final Reshape so the seq dim passes
+        // through dynamically. Final rank is 4 to satisfy the matcher's predicate.
+        auto expand_cos_sin = [&](Output<Node> cs) {
+            auto cs_unsq = std::make_shared<ov::op::v0::Unsqueeze>(
+                cs, ov::op::v0::Constant::create(ov::element::i64, {1}, {-1}));
+            auto bcast_target = ov::op::v0::Constant::create(
+                ov::element::i64, {5}, std::vector<int64_t>{1, 1, 1, half, 2});
+            auto bcast = std::make_shared<ov::op::v3::Broadcast>(
+                cs_unsq, bcast_target, ov::op::BroadcastType::BIDIRECTIONAL);
+            auto flat = ov::op::v0::Constant::create(
+                ov::element::i64, {4}, std::vector<int64_t>{0, 0, 0, head_size});
+            return std::make_shared<ov::op::v1::Reshape>(bcast, flat, true);
+        };
+        Output<Node> cos_full = expand_cos_sin(cos_theta_node);
+        Output<Node> sin_full = expand_cos_sin(sin_theta_node);
+
+        auto y1 = std::make_shared<ov::op::v1::Multiply>(data_node, cos_full);
+        auto y2 = std::make_shared<ov::op::v1::Multiply>(x_rotated, sin_full);
+        res = std::make_shared<ov::op::v1::Add>(y1, y2);
+    } else if (mode == TYPE_NORMAL) {
+        // Stateful path keeps the original even/odd Slice form unchanged. Stateful's
+        // KV layout already lets the GPU plugin's KVCacheFusion + UnsqueezeBroadcast-
+        // ReshapeSDPAFusion handle GQA, so rewriting RoPE there is unnecessary and
+        // would require extra rank-3 / rank-4 plumbing.
         auto neg_one = ov::op::v0::Constant::create(ov::element::i64, {1}, {-1});
         auto zero = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
         auto one = ov::op::v0::Constant::create(ov::element::i64, {1}, {1});
@@ -95,7 +155,8 @@ OutputVector translate_rope(const NodeContext & context) {
         auto end = ov::op::v0::Constant::create(ov::element::i64, {1}, {output_shape[3]});
         Output<Node> even_slice;
         Output<Node> odd_slice;
-        int32_t unsqueeze_dim = context.is_stateful() ? 3 : 4;
+        //int32_t unsqueeze_dim = context.is_stateful() ? 3 : 4;
+        int32_t unsqueeze_dim = 3; // stateful: data is rank 3, so unsqueeze at axis 3
         even_slice = std::make_shared<ov::op::v8::Slice>(data_node, zero, end, two, neg_one);
         odd_slice = std::make_shared<ov::op::v8::Slice>(data_node, one, end, two, neg_one);
 


### PR DESCRIPTION
- Stateless translation updated so gpu plugin can capture ov::op::internal::RoPE
- Temporary performance solution for stateless gpu: Bypass v13 SDPA entirely. Express attention manually so MatMul's NUMPY broadcast handles the GQA expansion at kernel level. K and V stay at n_heads_kv shape; the GEMM kernel reads them once and broadcasts via stride trick. We can revert this once we can utilize internal SDPA kernel which supports GQA broadcasting.
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>
<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/mcavus/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/mcavus/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:0%;}
.xl66
	{vertical-align:middle;
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:1.0pt solid windowtext;
	background:#A6C9EC;
	mso-pattern:black none;
	white-space:normal;}
.xl67
	{border-top:none;
	border-right:1.0pt solid windowtext;
	border-bottom:none;
	border-left:none;
	background:#DAE9F8;
	mso-pattern:black none;}
.xl68
	{mso-number-format:Fixed;
	background:#F2F2F2;
	mso-pattern:black none;}
.xl69
	{vertical-align:middle;
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:.5pt solid windowtext;
	border-left:1.0pt solid windowtext;
	background:#A6C9EC;
	mso-pattern:black none;
	white-space:normal;}
.xl70
	{border-top:none;
	border-right:1.0pt solid windowtext;
	border-bottom:.5pt solid windowtext;
	border-left:none;
	background:#DAE9F8;
	mso-pattern:black none;}
.xl71
	{mso-number-format:Fixed;
	border-top:none;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;
	background:#F2F2F2;
	mso-pattern:black none;}
.xl72
	{mso-number-format:Fixed;
	background:#D9D9D9;
	mso-pattern:black none;}
.xl73
	{text-align:right;
	vertical-align:middle;
	background:#FBE2D5;
	mso-pattern:black none;}
.info
	{font-size:11.0pt;
	font-family:"Aptos Narrow", sans-serif;
	margin-bottom:8px;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">

<div class="info"><b>Architecture:</b> Intel(R) Core(TM) Ultra 5 238V</div>
<div class="info"><b>Device:</b> GPU</div>
<div class="info"><b>Workload:</b> Token generation only</div>
<div class="info"><b>Metric:</b> Tokens per second</div>
<div class="info"><b>Mode:</b> Stateless only</div>

<br>

<table border="1" cellspacing="0" cellpadding="3">
  <tr>
    <td><b>Model</b></td>
    <td><b>ctx depth</b></td>
    <td><b>dev_backend_openvino</b></td>
    <td><b>stateless_optimizations</b></td>
    <td><b>speedup</b></td>
  </tr>
  <tr>
    <td>Llama-3.2-1B-Instruct.Q4_K_M</td>
    <td>0</td>
    <td>57.23</td>
    <td>69.34</td>
    <td>21%</td>
  </tr>
  <tr>
    <td></td>
    <td>512</td>
    <td>38.81</td>
    <td>59.77</td>
    <td>54%</td>
  </tr>
  <tr>
    <td></td>
    <td>1024</td>
    <td>22.30</td>
    <td>50.49</td>
    <td>126%</td>
  </tr>
</table>

</body>
</html>