### PR TITLE
disable add_rope_sin_cos optimization

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -595,7 +595,7 @@ void GgmlOvDecoder::add_extra_inputs() {
     if (m_compute_params.token_len_per_seq != -1) {
         create_1d_input("token_len_per_seq", m_compute_params.token_len_per_seq);
     }
-    // create_1d_input("token_len", m_token_len_per_seq * m_n_seq_active);
+    // create_1d_input("token_len", m_compute_params.token_len_per_seq * m_compute_params.n_seq_active);
 }
 
 bool GgmlOvDecoder::node_is_used_as_src(const int node_idx) {

--- a/ggml/src/ggml-openvino/openvino/op/rope.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/rope.cpp
@@ -55,16 +55,7 @@ OutputVector translate_rope(const NodeContext & context) {
         if (context.get_input_size() == 3) {
             rope_freqs_weight = context.get_input(2).get_node_shared_ptr();
         }
-        std::shared_ptr<ov::Node> token_len_per_seq;
-        if (context.has_input("token_len_per_seq")) {
-            token_len_per_seq = context.get_input("token_len_per_seq").get_node_shared_ptr();
-        }
-        auto sin_cos = make_sin_cos(op_params,
-                                    inp_pos,
-                                    rope_freqs_weight,
-                                    mode == TYPE_IMROPE,
-                                    false,
-                                    token_len_per_seq);
+        auto sin_cos = make_sin_cos(op_params, inp_pos, rope_freqs_weight, mode == TYPE_IMROPE, false);
         sin_theta_node = sin_cos.first;
         cos_theta_node = sin_cos.second;
     }

--- a/ggml/src/ggml-openvino/openvino/translate_session.cpp
+++ b/ggml/src/ggml-openvino/openvino/translate_session.cpp
@@ -124,12 +124,6 @@ void add_rope_sin_cos(TensorMap & tensor_map, GgmlDecoder & ggml_model_decoder) 
     if (ggml_model_decoder.has_mixed_rope_params()) {
         return;
     }
-    // Dynamic active-sequence slicing is reconstructed per ROPE node. Reusing a
-    // single shared rope_sin/rope_cos across the whole graph is unsafe here,
-    // because the graph-level inp_pos does not necessarily match each ROPE use.
-    if (tensor_map.find("seq_active_start") != tensor_map.end() && tensor_map.find("seq_active_end") != tensor_map.end()) {
-        return;
-    }
     int32_t * rope_params = ggml_model_decoder.get_rope_params();
     if (tensor_map.find("inp_pos") == tensor_map.end() || rope_params == nullptr) {
         return;
@@ -155,7 +149,8 @@ void preprocess(TensorMap & tensor_map, GgmlDecoder & ggml_model_decoder) {
     if (ggml_model_decoder.is_stateful()) {
         add_sliced_mask_stateful(tensor_map);
     }
-    add_rope_sin_cos(tensor_map, ggml_model_decoder);
+    // This optimization is error-prone
+    // add_rope_sin_cos(tensor_map, ggml_model_decoder);
 }
 
 }  // namespace

--- a/ggml/src/ggml-openvino/openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/openvino/utils.cpp
@@ -121,8 +121,7 @@ std::pair<ov::Output<Node>, ov::Output<Node>> make_sin_cos(int32_t * rope_params
                                                            std::shared_ptr<ov::Node> inp_pos,
                                                            std::shared_ptr<ov::Node> rope_freqs_weight,
                                                            bool imrope,
-                                                           bool stateful,
-                                                           std::shared_ptr<ov::Node> token_len_per_seq) {
+                                                           bool stateful) {
     if (stateful) {
         inp_pos = std::make_shared<ov::op::v0::Squeeze>(inp_pos, ov::op::v0::Constant::create(ov::element::i64, {1}, {0}));
         inp_pos = std::make_shared<ov::op::v0::Convert>(inp_pos, ov::element::f32);
@@ -141,13 +140,6 @@ std::pair<ov::Output<Node>, ov::Output<Node>> make_sin_cos(int32_t * rope_params
         auto pos_perm =
             std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{4}, std::vector<int64_t>{0, 3, 1, 2});
         inp_pos = std::make_shared<ov::op::v1::Transpose>(inp_pos, pos_perm);
-
-        if (!imrope && token_len_per_seq) {
-            auto zero = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
-            auto one = ov::op::v0::Constant::create(ov::element::i64, {1}, {1});
-            auto axis = ov::op::v0::Constant::create(ov::element::i64, {1}, {1});
-            inp_pos = std::make_shared<ov::op::v8::Slice>(inp_pos, zero, token_len_per_seq, one, axis);
-        }
     }
 
     float freq_base;

--- a/ggml/src/ggml-openvino/openvino/utils.h
+++ b/ggml/src/ggml-openvino/openvino/utils.h
@@ -64,12 +64,11 @@ std::shared_ptr<ov::Node> get_dimensions(const std::shared_ptr<ov::Node>& node, 
 
 OutputVector rename_outputs_with_suffix(const OutputVector& outputs, const std::string& suffix);
 
-std::pair<ov::Output<Node>, ov::Output<Node>> make_sin_cos(int32_t* rope_params,
+std::pair<ov::Output<Node>, ov::Output<Node>> make_sin_cos(int32_t * rope_params,
                                                            std::shared_ptr<ov::Node> inp_pos,
                                                            std::shared_ptr<ov::Node> rope_freqs_weight = nullptr,
                                                            bool imrope = false,
-                                                           bool stateful = false,
-                                                           std::shared_ptr<ov::Node> token_len_per_seq = nullptr);
+                                                           bool stateful = false);
 
 ov::Output<ov::Node> process_view_input(const NodeContext& context, int input_index, int slice_len = 0);
 


### PR DESCRIPTION
- Disabled `add_rope_sin_cos` since it is not working for a lot of advanced models
- @zhaixuejun1993 Reverted changes in https://github.com/ravi9/llama.cpp/pull/180 since it broke llama-perplexity. By disabling `add_rope_sin_cos` llama-test-archs still works without those changes