### PR TITLE
OpenVINO backend: add REPEAT translator, Q5_1 weights, and GLU view-input fix

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -835,7 +835,8 @@ std::shared_ptr<ov::Node> GgmlOvDecoder::create_weight_node(ggml_tensor * tensor
     // GGML_LOG_DEBUG("%s: creating new weight node for %s\n", __func__, tensor->name);
     static const std::set<ggml_type> weight_types = {GGML_TYPE_F32,  GGML_TYPE_F16,  GGML_TYPE_BF16,
                                                      GGML_TYPE_Q8_0, GGML_TYPE_Q4_0, GGML_TYPE_Q4_1,
-                                                     GGML_TYPE_Q4_K, GGML_TYPE_Q5_K, GGML_TYPE_Q6_K};
+                                                     GGML_TYPE_Q5_1, GGML_TYPE_Q4_K, GGML_TYPE_Q5_K,
+                                                     GGML_TYPE_Q6_K};
     if (weight_types.find(tensor->type) == weight_types.end()) {
         throw std::runtime_error("Unexpected weight tensor type: " + std::string(tensor->name) + " with type " +
                                  ggml_type_name(tensor->type));
@@ -1294,6 +1295,7 @@ std::string GgmlOvDecoder::compute_op_type(const ggml_tensor * node) {
         {GGML_OP_SSM_CONV,        "GGML_OP_SSM_CONV"       },
         {GGML_OP_GATED_DELTA_NET, "GGML_OP_GATED_DELTA_NET"},
         {GGML_OP_ARGSORT,         "GGML_OP_ARGSORT"        },
+        {GGML_OP_REPEAT,          "GGML_OP_REPEAT"         },
         {GGML_OP_IM2COL,          "GGML_OP_IM2COL"         }
     };
     static const std::map<ggml_unary_op, std::string> unary_ops = {

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
@@ -298,6 +298,10 @@ ggml_openvino_extracted_layout ggml_openvino_get_extracted_layout(const ggml_ten
         layout.is_symmetric = true;
         break;
 
+    case GGML_TYPE_Q5_1:
+        // u8 weights (5-bit values), asymmetric (scale + zero point)
+        break;
+
     case GGML_TYPE_Q6_K:
         layout.weights_per_block = 16;
         layout.is_symmetric = true;

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -1140,7 +1140,7 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
 
     static std::unordered_set<ggml_type> supported_types{GGML_TYPE_F32,  GGML_TYPE_F16,  GGML_TYPE_BF16, GGML_TYPE_I64,
                                                GGML_TYPE_I32,  GGML_TYPE_Q4_0, GGML_TYPE_Q4_1, GGML_TYPE_Q4_K,
-                                               GGML_TYPE_Q5_K, GGML_TYPE_Q8_0, GGML_TYPE_Q6_K};
+                                               GGML_TYPE_Q5_1, GGML_TYPE_Q5_K, GGML_TYPE_Q8_0, GGML_TYPE_Q6_K};
 
     // derive supported op sets from the op_table map, keys in
     // the map use the full macro name (e.g. "GGML_OP_ADD"), while

--- a/ggml/src/ggml-openvino/ggml-quants.cpp
+++ b/ggml/src/ggml-openvino/ggml-quants.cpp
@@ -142,6 +142,13 @@ void extract_q5_1_data(const ggml_tensor * tensor,
     auto * weights = static_cast<uint8_t *>(weights_arr.data());  // u8 weights, one byte per weight
     auto * scales = scales_arr.data<ov::element_type_traits<ov::element::f16>::value_type>();
 
+    // Read a 16-bit little-endian value without aliasing/const-qual violations.
+    auto read_u16 = [](const uint8_t * p) {
+        uint16_t v;
+        memcpy(&v, p, sizeof(v));
+        return v;
+    };
+
     auto unpack_block = [&](const uint8_t * block, uint8_t * dst) {
         uint32_t qh;
         memcpy(&qh, block + 4, sizeof(uint32_t));
@@ -161,8 +168,8 @@ void extract_q5_1_data(const ggml_tensor * tensor,
         auto * bias = zp_arr.data<ov::element_type_traits<ov::element::f16>::value_type>();
         ov::parallel_for(scales_arr.get_size(), [&](size_t i) {
             const uint8_t * block = data + i * bytes_per_block;
-            float scale = static_cast<float>(ov::float16::from_bits(*((uint16_t *) (block))));
-            float min = static_cast<float>(ov::float16::from_bits(*((uint16_t *) (block + 2))));
+            float scale = static_cast<float>(ov::float16::from_bits(read_u16(block)));
+            float min = static_cast<float>(ov::float16::from_bits(read_u16(block + 2)));
             scales[i] = ov::float16(scale);
             bias[i] = ov::float16(min);
             unpack_block(block, weights + i * qk);
@@ -171,8 +178,8 @@ void extract_q5_1_data(const ggml_tensor * tensor,
         auto * zp = static_cast<uint8_t *>(zp_arr.data());  // u8 zero points
         ov::parallel_for(scales_arr.get_size(), [&](size_t i) {
             const uint8_t * block = data + i * bytes_per_block;
-            float scale = static_cast<float>(ov::float16::from_bits(*((uint16_t *) (block))));
-            float min = static_cast<float>(ov::float16::from_bits(*((uint16_t *) (block + 2))));
+            float scale = static_cast<float>(ov::float16::from_bits(read_u16(block)));
+            float min = static_cast<float>(ov::float16::from_bits(read_u16(block + 2)));
             scales[i] = ov::float16(scale);
             // zp = -min / scale (dequant: (w - zp) * s == w*s + min)
             zp[i] = (scale != 0.0f) ? (uint8_t) std::lround(-min / scale) : 0;

--- a/ggml/src/ggml-openvino/ggml-quants.cpp
+++ b/ggml/src/ggml-openvino/ggml-quants.cpp
@@ -126,6 +126,61 @@ void extract_q4_1_data(const ggml_tensor * tensor,
     }
 }
 
+// Extracts (weight, scales, zp) from Q5_1 tensors.
+// Data layout is: |16 bit scale|16 bit min|32 bit qh (5th bits)|32 x 4bit low nibbles|.
+// Reconstructed quant q in [0,31]: q = (low nibble) | (qh_bit << 4). Dequant: w*d + m.
+// Weights are stored as u8 (5-bit values do not fit u4), matching make_int8_weights.
+void extract_q5_1_data(const ggml_tensor * tensor,
+                       ov::Tensor & weights_arr,
+                       ov::Tensor & scales_arr,
+                       ov::Tensor & zp_arr,
+                       bool use_bias) {
+    const uint64_t bytes_per_block = 24;  // 2 scale + 2 min + 4 qh + 16 (32x0.5) weights
+    const int qk = 32;
+
+    auto * data = static_cast<uint8_t *>(tensor->data);
+    auto * weights = static_cast<uint8_t *>(weights_arr.data());  // u8 weights, one byte per weight
+    auto * scales = scales_arr.data<ov::element_type_traits<ov::element::f16>::value_type>();
+
+    auto unpack_block = [&](const uint8_t * block, uint8_t * dst) {
+        uint32_t qh;
+        memcpy(&qh, block + 4, sizeof(uint32_t));
+        const uint8_t * qs = block + 8;
+        for (int j = 0; j < qk / 2; ++j) {
+            const uint8_t lo = qs[j] & 0x0F;
+            const uint8_t hi = qs[j] >> 4;
+            const uint8_t bit_lo = (qh >> j) & 1;
+            const uint8_t bit_hi = (qh >> (j + qk / 2)) & 1;
+            dst[j] = lo | (bit_lo << 4);                 // first 16 weights
+            dst[j + qk / 2] = hi | (bit_hi << 4);        // last 16 weights
+        }
+    };
+
+    if (use_bias) {
+        // Store bias (min) directly as f16: dequant w*d + m
+        auto * bias = zp_arr.data<ov::element_type_traits<ov::element::f16>::value_type>();
+        ov::parallel_for(scales_arr.get_size(), [&](size_t i) {
+            const uint8_t * block = data + i * bytes_per_block;
+            float scale = static_cast<float>(ov::float16::from_bits(*((uint16_t *) (block))));
+            float min = static_cast<float>(ov::float16::from_bits(*((uint16_t *) (block + 2))));
+            scales[i] = ov::float16(scale);
+            bias[i] = ov::float16(min);
+            unpack_block(block, weights + i * qk);
+        });
+    } else {
+        auto * zp = static_cast<uint8_t *>(zp_arr.data());  // u8 zero points
+        ov::parallel_for(scales_arr.get_size(), [&](size_t i) {
+            const uint8_t * block = data + i * bytes_per_block;
+            float scale = static_cast<float>(ov::float16::from_bits(*((uint16_t *) (block))));
+            float min = static_cast<float>(ov::float16::from_bits(*((uint16_t *) (block + 2))));
+            scales[i] = ov::float16(scale);
+            // zp = -min / scale (dequant: (w - zp) * s == w*s + min)
+            zp[i] = (scale != 0.0f) ? (uint8_t) std::lround(-min / scale) : 0;
+            unpack_block(block, weights + i * qk);
+        });
+    }
+}
+
 // Extracts (weight, scales, zp) from Q8_0 tensors.
 // Data layout is: |16 bit scale|32 x 8bit weights|.
 // When zp_arr is empty (symmetric), weights are stored as signed i8 directly.
@@ -577,6 +632,7 @@ std::shared_ptr<ov::Node> extract_quantized_weights(const ggml_tensor * tensor,
         weights_per_block = 32;
         break;
     case GGML_TYPE_Q8_0:
+    case GGML_TYPE_Q5_1:
     case GGML_TYPE_Q5_K:
         is_u4 = false;
         weights_per_block = 32;
@@ -600,6 +656,9 @@ std::shared_ptr<ov::Node> extract_quantized_weights(const ggml_tensor * tensor,
         break;
     case GGML_TYPE_Q4_K:
         extract_q4_k_data(&temp_tensor, weights, scales, zp, use_bias);
+        break;
+    case GGML_TYPE_Q5_1:
+        extract_q5_1_data(&temp_tensor, weights, scales, zp, use_bias);
         break;
     case GGML_TYPE_Q8_0:
         extract_q8_0_data(&temp_tensor, weights, scales, zp);

--- a/ggml/src/ggml-openvino/ggml-quants.h
+++ b/ggml/src/ggml-openvino/ggml-quants.h
@@ -19,6 +19,12 @@ void extract_q4_1_data(const ggml_tensor * tensor,
                        ov::Tensor & zp_arr,
                        bool use_bias = false);
 
+void extract_q5_1_data(const ggml_tensor * tensor,
+                       ov::Tensor & weights_arr,
+                       ov::Tensor & scales_arr,
+                       ov::Tensor & zp_arr,
+                       bool use_bias = false);
+
 void extract_q8_0_data(const ggml_tensor * tensor,
                        ov::Tensor & weights_arr,
                        ov::Tensor & scales_arr,

--- a/ggml/src/ggml-openvino/openvino/op/glu_geglu.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/glu_geglu.cpp
@@ -22,13 +22,16 @@ OutputVector translate_glu_geglu(const NodeContext & context) {
     ov::Output<ov::Node> src0;
     ov::Output<ov::Node> src1;
     if (context.get_input_size() == 2) {
-        src0 = context.get_input(0);
-        src1 = context.get_input(1);
+        // Inputs may be VIEW slices of a combined gate_up tensor (MoE experts):
+        // resolve them so each half has its real sliced shape, not the base tensor.
+        src0 = process_view_input_new(context, 0);
+        src1 = process_view_input_new(context, 1);
     } else {
         // GGML splits along ne[0] (OV last axis) using floor division: nc = ne[0] / 2.
         // Both halves are nc elements; if the dimension is odd, the last element is dropped.
         // Use Slice instead of Split to handle odd dimensions correctly.
-        auto combined = context.get_input(0);
+        // Resolve a VIEW input (e.g. non-contiguous slice) to its real shape first.
+        auto combined = process_view_input_new(context, 0);
         auto combined_shape = combined.get_partial_shape();
         int64_t last_dim_val = combined_shape[combined_shape.rank().get_length() - 1].get_length();
         int64_t nc = last_dim_val / 2;

--- a/ggml/src/ggml-openvino/openvino/op/glu_swiglu.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/glu_swiglu.cpp
@@ -21,13 +21,16 @@ OutputVector translate_glu_swiglu(const NodeContext & context) {
     ov::Output<ov::Node> src0;
     ov::Output<ov::Node> src1;
     if (context.get_input_size() == 2) {
-        src0 = context.get_input(0);
-        src1 = context.get_input(1);
+        // Inputs may be VIEW slices of a combined gate_up tensor (MoE experts):
+        // resolve them so each half has its real sliced shape, not the base tensor.
+        src0 = process_view_input_new(context, 0);
+        src1 = process_view_input_new(context, 1);
     } else {
         // GGML splits along ne[0] (OV last axis) using floor division: nc = ne[0] / 2.
         // Both halves are nc elements; if the dimension is odd, the last element is dropped.
         // Use Slice instead of Split to handle odd dimensions correctly.
-        auto combined = context.get_input(0);
+        // Resolve a VIEW input (e.g. non-contiguous slice) to its real shape first.
+        auto combined = process_view_input_new(context, 0);
         auto combined_shape = combined.get_partial_shape();
         int64_t last_dim_val = combined_shape[combined_shape.rank().get_length() - 1].get_length();
         int64_t nc = last_dim_val / 2;

--- a/ggml/src/ggml-openvino/openvino/op/repeat.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/repeat.cpp
@@ -1,0 +1,75 @@
+#include "../node_context.h"
+#include "../op_table.h"
+#include "../utils.h"
+
+#include "ggml.h"
+
+#include <memory>
+#include <openvino/op/broadcast.hpp>
+#include <openvino/op/constant.hpp>
+#include <openvino/op/divide.hpp>
+#include <openvino/op/shape_of.hpp>
+#include <openvino/op/tile.hpp>
+#include <vector>
+
+namespace ov {
+namespace frontend {
+namespace ggml {
+namespace op {
+
+// GGML_OP_REPEAT tiles src[0] to fill the destination shape. Every destination
+// dimension is an integer multiple of the corresponding source dimension.
+OutputVector translate_repeat(const NodeContext & context) {
+    num_inputs_check(context, 1, 2);
+
+    auto input = process_view_input_new(context, 0);
+
+    const auto input_shape = context.get_input_shape(0);
+    const auto output_shape = context.get_output_shape();
+
+    if (input_shape.rank().is_static() && output_shape.rank().is_static() &&
+        input_shape.rank() == output_shape.rank()) {
+        const auto rank = static_cast<size_t>(input_shape.rank().get_length());
+        std::vector<int64_t> repeats(rank, 1);
+        bool all_static = true;
+
+        for (size_t axis = 0; axis < rank; ++axis) {
+            if (!input_shape[axis].is_static() || !output_shape[axis].is_static()) {
+                all_static = false;
+                break;
+            }
+
+            const int64_t input_dim = input_shape[axis].get_length();
+            const int64_t output_dim = output_shape[axis].get_length();
+
+            FRONT_END_OP_CONVERSION_CHECK(input_dim > 0 && output_dim > 0 && output_dim % input_dim == 0,
+                                          "REPEAT input shape ", input_shape, " cannot tile to match ", output_shape);
+
+            repeats[axis] = output_dim / input_dim;
+        }
+
+        if (all_static) {
+            auto repeats_node = ov::op::v0::Constant::create(ov::element::i64, {repeats.size()}, repeats);
+            ov::Output<ov::Node> res = std::make_shared<ov::op::v0::Tile>(input, repeats_node);
+            return rename_outputs_with_suffix({res}, context.get_name());
+        }
+    }
+
+    // Dynamic fallback: tile by the ratio of output to input shape.
+    auto input_shape_node = std::make_shared<ov::op::v3::ShapeOf>(input, ov::element::i64);
+    std::shared_ptr<ov::Node> target_shape_node;
+    if (output_shape.rank().is_static() && output_shape.is_static()) {
+        target_shape_node =
+            ov::op::v0::Constant::create(ov::element::i64, {output_shape.to_shape().size()}, output_shape.to_shape());
+    } else {
+        target_shape_node = std::make_shared<ov::op::v3::ShapeOf>(context.get_input(1), ov::element::i64);
+    }
+    auto repeats_node = std::make_shared<ov::op::v1::Divide>(target_shape_node, input_shape_node);
+    ov::Output<ov::Node> res = std::make_shared<ov::op::v0::Tile>(input, repeats_node);
+    return rename_outputs_with_suffix({res}, context.get_name());
+}
+
+}  // namespace op
+}  // namespace ggml
+}  // namespace frontend
+}  // namespace ov

--- a/ggml/src/ggml-openvino/openvino/op_table.cpp
+++ b/ggml/src/ggml-openvino/openvino/op_table.cpp
@@ -54,6 +54,7 @@ std::unordered_map<std::string, CreatorFunction> get_supported_ops() {
         {"GGML_OP_PAD",             op::translate_pad                              },
         {"GGML_OP_SSM_CONV",        op::translate_ssm_conv                         },
         {"GGML_OP_GATED_DELTA_NET", op::translate_gated_delta_net                  },
+        {"GGML_OP_REPEAT",          op::translate_repeat                           },
     };
 }
 

--- a/ggml/src/ggml-openvino/openvino/op_table.h
+++ b/ggml/src/ggml-openvino/openvino/op_table.h
@@ -40,6 +40,7 @@ GGML_OP_CONVERTER(translate_clamp);
 GGML_OP_CONVERTER(translate_pad);
 GGML_OP_CONVERTER(translate_ssm_conv);
 GGML_OP_CONVERTER(translate_gated_delta_net);
+GGML_OP_CONVERTER(translate_repeat);
 
 } // namespace op
 


### PR DESCRIPTION
    - REPEAT: new translate_repeat (Tile-based) + op_table registration +
      op-type-name map entry
    - Q5_1: extract_q5_1_data dequantizer + extract dispatch, extracted-layout
      case, and add GGML_TYPE_Q5_1 to supported_types / weight_types
    - GEGLU/SWIGLU: resolve VIEW-sliced inputs via process_view_input_new so the
      MoE fused gate_up halves get their real sliced shapes