### PR TITLE
OpenVINO backend: Enable GGML_OP_ADD_ID

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -1267,6 +1267,7 @@ std::string GgmlOvDecoder::compute_op_type(const ggml_tensor * node) {
         {GGML_OP_ACC,             "GGML_OP_ACC"            },
         {GGML_OP_ADD,             "GGML_OP_ADD"            },
         {GGML_OP_ADD1,            "GGML_OP_ADD1"           },
+        {GGML_OP_ADD_ID,          "GGML_OP_ADD_ID"         },
         {GGML_OP_CONCAT,          "GGML_OP_CONCAT"         },
         {GGML_OP_CONT,            "GGML_OP_CONT"           },
         {GGML_OP_DIV,             "GGML_OP_DIV"            },

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -923,6 +923,16 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         }
         break;
     }
+    case GGML_OP_ADD_ID: {
+        // Keep support aligned with the CPU backend implementation, which only handles f32 inputs/output and i32 ids.
+        if (op->type != GGML_TYPE_F32 ||
+            op->src[0]->type != GGML_TYPE_F32 ||
+            op->src[1]->type != GGML_TYPE_F32 ||
+            op->src[2]->type != GGML_TYPE_I32) {
+            return true;
+        }
+        break;
+    }
     case GGML_OP_DIV: {
         bool requires_broadcast = false;
         for (int i = 0; i < 4; i++) {

--- a/ggml/src/ggml-openvino/openvino/op/add_id.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/add_id.cpp
@@ -1,0 +1,63 @@
+#include "../node_context.h"
+#include "../op_table.h"
+#include "../utils.h"
+
+#include <openvino/core/node.hpp>
+#include <openvino/core/node_output.hpp>
+#include <openvino/op/add.hpp>
+#include <openvino/op/constant.hpp>
+#include <openvino/op/convert.hpp>
+#include <openvino/op/gather.hpp>
+#include <openvino/op/reshape.hpp>
+#include <openvino/op/shape_of.hpp>
+
+#include <memory>
+
+namespace ov {
+namespace frontend {
+namespace ggml {
+namespace op {
+
+OutputVector translate_add_id(const NodeContext & context) {
+    num_inputs_check(context, 3, 3);
+
+    auto input = process_view_input_new(context, 0);
+    auto bias = process_view_input_new(context, 1);
+    auto ids = process_view_input_new(context, 2);
+
+    // OpenVINO uses reversed GGML dimensions:
+    //   input: [1, n_token, n_used, n_embd]
+    //   bias:  [1, 1, n_expert, n_embd]
+    //   ids:   [1, 1, n_token, n_used]
+    auto bias_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(bias, ov::element::i64);
+    auto ids_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(ids, ov::element::i64);
+
+    bias = std::make_shared<ov::op::v1::Reshape>(bias, get_dimensions(bias_shape_4d, {2, 3}), false);
+    ids = std::make_shared<ov::op::v1::Reshape>(ids, get_dimensions(ids_shape_4d, {2, 3}), false);
+
+    if (ids.get_element_type() != ov::element::i32 && ids.get_element_type() != ov::element::i64) {
+        ids = std::make_shared<ov::op::v0::Convert>(ids, ov::element::i32);
+    }
+
+    auto gather_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
+    ov::Output<ov::Node> selected_bias = std::make_shared<ov::op::v8::Gather>(bias, ids, gather_axis);
+    selected_bias = std::make_shared<ov::op::v1::Reshape>(
+        selected_bias, std::make_shared<ov::op::v3::ShapeOf>(input, ov::element::i64), false);
+
+    if (selected_bias.get_element_type() != input.get_element_type()) {
+        selected_bias = std::make_shared<ov::op::v0::Convert>(selected_bias, input.get_element_type());
+    }
+
+    ov::Output<ov::Node> res = std::make_shared<ov::op::v1::Add>(input, selected_bias);
+    const auto output_type = context.get_output_type();
+    if (res.get_element_type() != output_type) {
+        res = std::make_shared<ov::op::v0::Convert>(res, output_type);
+    }
+
+    return rename_outputs_with_suffix({res}, context.get_name());
+}
+
+}  // namespace op
+}  // namespace ggml
+}  // namespace frontend
+}  // namespace ov

--- a/ggml/src/ggml-openvino/openvino/op_table.cpp
+++ b/ggml/src/ggml-openvino/openvino/op_table.cpp
@@ -20,6 +20,7 @@ std::unordered_map<std::string, CreatorFunction> get_supported_ops() {
     return {
         {"GGML_OP_ADD",             op::translate_1to1_match_2_inputs<v1::Add>     },
         {"GGML_OP_ADD1",            op::translate_1to1_match_2_inputs<v1::Add>     },
+        {"GGML_OP_ADD_ID",          op::translate_add_id                           },
         {"GGML_OP_CONCAT",          op::translate_concat                           },
         {"GGML_OP_CONT",            op::translate_cont                             },
         {"GGML_OP_DIV",             op::translate_div                              },

--- a/ggml/src/ggml-openvino/openvino/op_table.h
+++ b/ggml/src/ggml-openvino/openvino/op_table.h
@@ -12,6 +12,7 @@ namespace op {
 
 GGML_OP_CONVERTER(translate_cont);
 GGML_OP_CONVERTER(translate_concat);
+GGML_OP_CONVERTER(translate_add_id);
 GGML_OP_CONVERTER(translate_div);
 GGML_OP_CONVERTER(translate_get_rows);
 GGML_OP_CONVERTER(translate_im2col);


### PR DESCRIPTION
This pull request adds support for the `GGML_OP_ADD_ID` operation in the OpenVINO backend of GGML. The main changes introduce the translation logic for this operator, register it in the operator table, and ensure type compatibility with the CPU backend.

**New operator support:**

* Added a new implementation for the `GGML_OP_ADD_ID` operation in `openvino/op/add_id.cpp`, including logic to handle input, bias, and ids with appropriate reshaping, type conversion, and broadcasting.
* Registered the new `translate_add_id` converter in the operator table (`openvino/op_table.cpp`, `openvino/op_table.h`) and mapped it to the `"GGML_OP_ADD_ID"` string for operator dispatch. [[1]](diffhunk://#diff-38aeb0eac98ad08297d3a19c984ae6a3ce2b49a5e8954bb6318890eae57fc172R23) [[2]](diffhunk://#diff-d4d3b0b3b0ab3935c62621994cd590f91ae4e44b2ef6fb19bda765d2b5d6a9aaR15)
* Updated the operation type mapping in `ggml-decoder.cpp` to include `GGML_OP_ADD_ID`.

**Compatibility and validation:**

* Enhanced `is_op_unsupported_case` in `ggml-openvino.cpp` to only support `GGML_OP_ADD_ID` when the input/output types match the CPU backend's requirements (f32 for data, i32 for ids).## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
