### PR TITLE
ggml-openvino: add Gemma-4 26B MoE support

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -98,6 +98,15 @@ GgmlOvDecoder::GgmlOvDecoder(ggml_cgraph * cgraph, std::map<std::string, std::sh
     }
 }
 
+// VIEW outputs are keyed by name in the tensor_map, but several distinct VIEWs of
+// one source can share a ggml name (e.g. 8 per-expert views all named the same).
+// Disambiguate by appending the view offset and the tensor address so each VIEW
+// node maps to its own entry instead of colliding on the last writer.
+static std::string ggml_ov_unique_view_name(const ggml_tensor * t) {
+    return std::string(t->name) + "#voff" + std::to_string(t->view_offs) + "@" +
+           std::to_string(reinterpret_cast<uintptr_t>(t));
+}
+
 void GgmlOvDecoder::set_input_output() {
     for (int node_n = 0; node_n < m_cgraph->n_nodes; node_n++) {
         auto node = m_cgraph->nodes[node_n];
@@ -106,6 +115,9 @@ void GgmlOvDecoder::set_input_output() {
         auto node_name = std::string(node->name);
         auto node_output_name = node_name;
         auto * node_output = node;
+        if (node->op == GGML_OP_VIEW) {
+            node_output_name = ggml_ov_unique_view_name(node);
+        }
         if (node->op == GGML_OP_SET_ROWS) {
             // SET_ROWS updates the tensor in place. For later ov op that uses the
             // the view_src of SET_ROWS, we need to make sure they get the updated tensor
@@ -130,6 +142,8 @@ void GgmlOvDecoder::set_input_output() {
             auto src_name = std::string(src->name);
             if (src->flags & GGML_TENSOR_FLAG_INPUT) {
                 src_name = get_graph_input_ov_name(src, node);
+            } else if (src->op == GGML_OP_VIEW) {
+                src_name = ggml_ov_unique_view_name(src);
             }
             current_node_info.node_inputs[src_name] = src;
             current_node_info.node_inputs_names.push_back(src_name);
@@ -824,6 +838,30 @@ std::shared_ptr<ov::Node> GgmlOvDecoder::create_weight_node(ggml_tensor * tensor
         auto weight_node = std::make_shared<ov::op::v0::Constant>(weight_tensor);
         weight_node->set_friendly_name(tensor->name);
         return weight_node;
+    }
+
+    // 3D quantized MoE expert weights [k, m, n_expert]: flatten to a rank-2
+    // [n_expert, m*k] tensor and build the dequant subgraph with use_bias=true (the
+    // exact f16 zero-point form). This is the path hit by test-backend-ops and the
+    // host-buffer load; the backend-buffer path builds the same node in set_tensor.
+    // translate_mul_mat_id gathers experts on axis 0 of this node and splits m*k.
+    if (ggml_is_quantized(tensor->type) && tensor->ne[2] > 1) {
+        GGML_ASSERT(tensor->ne[3] == 1 && "4D quantized expert weights are not supported");
+        GGML_ASSERT(ggml_is_contiguous(tensor) && "expert weights must be contiguous to flatten");
+        const int64_t n_expert = tensor->ne[2];
+        const int64_t m = tensor->ne[1];
+        const int64_t k = tensor->ne[0];
+        ggml_tensor flat_tensor = *tensor;
+        flat_tensor.ne[0] = m * k;
+        flat_tensor.ne[1] = n_expert;
+        flat_tensor.ne[2] = 1;
+        flat_tensor.ne[3] = 1;
+        flat_tensor.nb[1] = ggml_row_size(tensor->type, m * k);
+        flat_tensor.nb[2] = ggml_nbytes(tensor);
+        flat_tensor.nb[3] = ggml_nbytes(tensor);
+        OvWeight flat_weight = process_weight_tensor(&flat_tensor, tensor->data, nullptr, /*use_bias=*/true);
+        flat_weight.weight_node->set_friendly_name(tensor->name);
+        return flat_weight.weight_node;
     }
 
     // There are three cases where we need to create a new weight node:

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
@@ -222,6 +222,14 @@ std::optional<ExtraQuantType> ggml_openvino_get_requant_type(const ggml_tensor *
         return std::nullopt;
     }
     if (strncmp(tensor->name, "token_embd.weight", 17) == 0) {
+        // On CPU/GPU, requantizing token_embd to channel-wise Q8_0_C (one scale per
+        // 2816-wide row) loses precision on the many small embedding values (they
+        // round to 0), measurably degrading output quality. Keep native extraction
+        // (per-32 block scales) on non-NPU. NPU still needs the requant for layout.
+        // Override with GGML_OPENVINO_EMBD_REQUANT=1.
+        if (!ggml_openvino_is_npu() && !getenv("GGML_OPENVINO_EMBD_REQUANT")) {
+            return std::nullopt;
+        }
         return ((ggml_openvino_is_npu() && tensor->type == GGML_TYPE_Q6_K) ? ExtraQuantType::F16 :
                                                                              ExtraQuantType::Q8_0_C);
     }
@@ -252,8 +260,10 @@ ggml_openvino_extracted_layout ggml_openvino_get_extracted_layout(const ggml_ten
         return layout;
     }
 
-    // Only handle 2D weight tensors
-    if (tensor->ne[2] != 1 || tensor->ne[3] != 1) {
+    // Handle 2D weight tensors, and 3D MoE expert weights [k, m, n_expert] which
+    // are treated as a flattened 2D [n_expert*m, k] tensor (each row is quantized
+    // independently along k, so the block layout is identical when flattened).
+    if (tensor->ne[3] != 1) {
         return layout;
     }
 
@@ -375,6 +385,10 @@ ggml_openvino_extracted_layout ggml_openvino_get_extracted_layout(const ggml_ten
     // For symmetric quantization, no zp needed (weights stored as signed)
     if (layout.is_symmetric) {
         layout.zp_size = 0;
+    } else if (use_bias) {
+        // use_bias stores the zero-point/bias as F16 (2 bytes/block), not a packed
+        // integer. Must size the buffer accordingly so the extracted data fits in-place.
+        layout.zp_size = n_blocks * sizeof(uint16_t);
     } else {
         layout.zp_size = layout.is_u4 ? ((n_blocks + 1) / 2) : n_blocks;
     }

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -235,12 +235,58 @@ static void ggml_backend_openvino_buffer_set_tensor(ggml_backend_buffer_t buffer
     bool is_weight_buffer = (buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
     // Full tensor set: offset=0, full size, not a view
     bool is_full_tensor_set = (offset == 0 && size == ggml_nbytes(tensor) && tensor->view_src == nullptr);
-    // 2D tensor (typical weight shape)
+    // 2D weight, or 3D MoE expert weight [k, m, n_expert] handled as flattened 2D.
     bool is_2d = (tensor->ne[2] == 1 && tensor->ne[3] == 1);
+    bool is_3d_expert = (tensor->ne[2] > 1 && tensor->ne[3] == 1 && ggml_is_quantized(tensor->type));
 
-    if (is_weight_buffer && is_full_tensor_set && is_2d) {
+    if (is_weight_buffer && is_full_tensor_set && (is_2d || is_3d_expert)) {
         try {
-            auto result = process_weight_tensor(tensor, data, tensor->data);
+            // Flatten 3D expert weights [k, m, n_expert] -> 2D [k, n_expert*m] so the
+            // extracted data is written in-place into this backend buffer (avoiding a
+            // large extra allocation), then reshape the dequant node back to 4D.
+            ggml_tensor proc_tensor = *tensor;
+            const int64_t n_expert = tensor->ne[2];
+            const int64_t m = tensor->ne[1];
+            const int64_t k = tensor->ne[0];
+            if (is_3d_expert) {
+                GGML_ASSERT(ggml_is_contiguous(tensor) && "3D expert weights must be contiguous");
+                // View the contiguous 3D expert tensor [k, m, n_expert] as a 2D tensor
+                // [m*k, n_expert] (ne[0]=m*k, ne[1]=n_expert): one quantized "row" of
+                // m*k weights per expert. This is bit-identical to the per-k-row
+                // quantization because k is a whole number of quant super-blocks for
+                // every expert type here (Q4_K: k%256==0, Q5_1: k%32==0), so regrouping
+                // the blocks does not change any block's contents.
+                //
+                // The 2D weight path then yields a rank-2 [n_expert, m*k] dequant
+                // subgraph: Constant(u4/u8) -> Convert -> [Subtract(zp)] -> Multiply
+                //   -> Reshape(3D->2D) -> Convert(f32).
+                // translate_mul_mat_id gathers experts on axis 0 of this node DIRECTLY,
+                // which lets the CPU plugin's ConvertGatherToGatherCompressed pass fuse
+                // the gather + dequant into a single GatherCompressed op. That keeps the
+                // weights COMPRESSED through compile_model and decompresses only the
+                // selected experts at runtime. Reshaping the dequant output to a 4D
+                // [1,n_expert,m,k] (the previous approach) breaks the fusion, so the
+                // plugin const-folds the entire decompressed constant (~87GB f32 for 30
+                // layers x 128 experts) and OOMs - disable_constant_folding does NOT
+                // help there (it just keeps both compressed and f32 copies).
+                proc_tensor.ne[0] = m * k;
+                proc_tensor.ne[1] = n_expert;
+                proc_tensor.ne[2] = 1;
+                proc_tensor.nb[1] = ggml_row_size(tensor->type, m * k);
+                proc_tensor.nb[2] = ggml_nbytes(tensor);
+                proc_tensor.nb[3] = ggml_nbytes(tensor);
+            }
+
+            // For 3D MoE experts use the accurate dequant (use_bias=true). This routes
+            // through the f16 zero-point Subtract form in make_int*_weights, which is
+            // exact (no round(min/scale) error that corrupts Q4_K/Q5_1 experts) AND
+            // still folds to GatherCompressed (stays compressed, no OOM).
+            auto result = is_3d_expert ? process_weight_tensor(&proc_tensor, data, tensor->data, /*use_bias=*/true,
+                                                               /*zp_buffer_is_f16=*/true)
+                                       : process_weight_tensor(&proc_tensor, data, tensor->data);
+            // For 3D experts, leave result.weight_node as the rank-2 [n_expert, m*k]
+            // dequant node - translate_mul_mat_id handles the expert gather and the
+            // m*k -> m,k split. Do NOT reshape to 4D or disable folding here.
             result.weight_node->set_friendly_name(tensor->name);
 
             // const auto & layout = result.layout;
@@ -458,9 +504,14 @@ static size_t ggml_backend_openvino_buffer_type_get_alloc_size(ggml_backend_buff
                                                                const ggml_tensor * tensor) {
     GGML_UNUSED(buft);
 
-    // For quantized 2D tensors (weights), we need extra space for extracted data
-    if (ggml_is_quantized(tensor->type) && tensor->ne[2] == 1 && tensor->ne[3] == 1) {
-        ggml_openvino_extracted_layout layout = ggml_openvino_get_extracted_layout(tensor);
+    // For quantized 2D tensors (weights) and 3D MoE expert weights, we need extra
+    // space for extracted data.
+    if (ggml_is_quantized(tensor->type) && tensor->ne[3] == 1) {
+        // 3D MoE experts are extracted with use_bias=true (f16 zero-point), which needs
+        // a larger zp slot - size the buffer with the same use_bias so the in-place
+        // extracted data fits (must match set_tensor's process_weight_tensor call).
+        const bool expert_use_bias = (tensor->ne[2] > 1);
+        ggml_openvino_extracted_layout layout = ggml_openvino_get_extracted_layout(tensor, expert_use_bias);
         if (layout.total_size > 0) {
             // GGML_LOG_DEBUG("%s: tensor %s needs %zu bytes (original %zu, extracted: weights=%zu scales=%zu zp=%zu)\n",
             //                __func__, tensor->name, layout.total_size, ggml_nbytes(tensor), layout.weights_size,
@@ -864,7 +915,12 @@ static bool mul_mat_id_requires_large_tmp(const ggml_tensor * op) {
 
     // The current OpenVINO translation materializes selected expert weights with
     // shape [n_tokens, n_used, rows, k]. Skip cases that would create a very
-    // large temporary on GPU and let the scheduler fall back instead.
+    // large temporary on GPU and let the scheduler fall back instead. The CPU
+    // device can handle the large intermediate, so only apply this cap on GPU.
+    if (ggml_openvino_get_device_name() != "GPU") {
+        return false;
+    }
+
     size_t tmp_elems = 1;
     if (!checked_mul_size(tmp_elems, static_cast<size_t>(ids->ne[1]), tmp_elems) ||
         !checked_mul_size(tmp_elems, static_cast<size_t>(ids->ne[0]), tmp_elems) ||
@@ -897,8 +953,10 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
 
         // Keep the MoE routing weights gather on CPU for GPU runs. Splitting
         // only at the later SUM/CLAMP/DIV nodes still leaves this routing path
-        // numerically unstable for arctic-style MoE graphs.
-        if (strncmp(op->name, "ffn_moe_weights", sizeof("ffn_moe_weights") - 1) == 0) {
+        // numerically unstable for arctic-style MoE graphs. The CPU device path
+        // is numerically stable, so only force this off on GPU.
+        if (ggml_openvino_get_device_name() == "GPU" &&
+            strncmp(op->name, "ffn_moe_weights", sizeof("ffn_moe_weights") - 1) == 0) {
             return true;
         }
         break;
@@ -953,8 +1011,10 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         }
 
         // qwen3next MoE weight normalization is numerically sensitive on the GPU
-        // path. Keep the normalization divide on CPU to match the reference.
-        if (strncmp(op->name, "ffn_moe_weights_norm", sizeof("ffn_moe_weights_norm") - 1) == 0) {
+        // path. Keep the normalization divide on CPU to match the reference. The
+        // CPU device path is stable, so only force this off on GPU.
+        if (ggml_openvino_get_device_name() == "GPU" &&
+            strncmp(op->name, "ffn_moe_weights_norm", sizeof("ffn_moe_weights_norm") - 1) == 0) {
             return true;
         }
         break;
@@ -965,7 +1025,8 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
             return true;
         }
 
-        if (strncmp(op->name, "ffn_moe_probs", sizeof("ffn_moe_probs") - 1) == 0) {
+        if (ggml_openvino_get_device_name() == "GPU" &&
+            strncmp(op->name, "ffn_moe_probs", sizeof("ffn_moe_probs") - 1) == 0) {
             return true;
         }
 
@@ -979,7 +1040,8 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         break;
     }
     case GGML_OP_SUM_ROWS: {
-        if (strncmp(op->name, "ffn_moe_weights_sum", sizeof("ffn_moe_weights_sum") - 1) == 0) {
+        if (ggml_openvino_get_device_name() == "GPU" &&
+            strncmp(op->name, "ffn_moe_weights_sum", sizeof("ffn_moe_weights_sum") - 1) == 0) {
             return true;
         }
 
@@ -990,7 +1052,8 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         break;
     }
     case GGML_OP_CLAMP: {
-        if (strncmp(op->name, "ffn_moe_weights_sum_clamped", sizeof("ffn_moe_weights_sum_clamped") - 1) == 0) {
+        if (ggml_openvino_get_device_name() == "GPU" &&
+            strncmp(op->name, "ffn_moe_weights_sum_clamped", sizeof("ffn_moe_weights_sum_clamped") - 1) == 0) {
             return true;
         }
         break;
@@ -1056,7 +1119,17 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
             op->src[0]->src[0]->src[0]->op == GGML_OP_PERMUTE) {
             return true;
         }
+        if (op->src[0]->type == GGML_TYPE_F16 && op->src[1]->type == GGML_TYPE_F16) {
+            // Has accuracy issue, try enabling this and see `test-backend-ops -o "MUL_MAT"`
+            // GGML_LOG_WARN("OpenVINO backend does not support MUL_MAT with two F16 tensors\n");
+            return true;
+        }
         if (op->src[0]->ne[3] != op->src[1]->ne[3] && op->src[0]->ne[3] != 1 && op->src[1]->ne[3] != 1) {
+            return true;
+        }
+        if (ggml_is_quantized(op->src[0]->type) && op->src[0]->ne[1] == 1) {
+            // MUL_MAT(type_a=q4_0,type_b=f32,m=1,n=2048,k=8192,bs=[1,1],nr=[1,1],per=[0,1,2,3],k_v=0,o=1)
+            // triggers a bug in ov matmul_shape_inference.hpp
             return true;
         }
         if (op->src[0]->op == GGML_OP_VIEW && op->src[1]->op == GGML_OP_VIEW) {
@@ -1065,8 +1138,12 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         break;
     }
     case GGML_OP_MUL_MAT_ID: {
-        if (strncmp(op->name, "ffn_moe_gate_up", sizeof("ffn_moe_gate_up") - 1) == 0 ||
-            strncmp(op->name, "ffn_moe_down", sizeof("ffn_moe_down") - 1) == 0) {
+        // ffn_moe_gate_up / ffn_moe_down expert matmuls were previously forced to
+        // CPU. With 3D quantized expert-weight dequantization in create_weight_node,
+        // they can run on the OpenVINO CPU path. Keep them on CPU only for GPU.
+        if (ggml_openvino_get_device_name() == "GPU" &&
+            (strncmp(op->name, "ffn_moe_gate_up", sizeof("ffn_moe_gate_up") - 1) == 0 ||
+             strncmp(op->name, "ffn_moe_down", sizeof("ffn_moe_down") - 1) == 0)) {
             return true;
         }
 
@@ -1147,14 +1224,6 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         // Keep this op on CPU until the OpenVINO implementation is fixed.
         return true;
     }
-    case GGML_OP_VIEW: {
-        // Skip TOPK_MOE fused tests until it is fully supported
-        // the argsort_top_k VIEW wrapping ARGSORT is named "selected_experts" in test_topk_moe
-        if (strcmp(op->name, "selected_experts") == 0) {
-            return true;
-        }
-        break;
-    }
     default:
         break;
     }
@@ -1221,7 +1290,7 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
             // GGML_LOG_WARN("OpenVINO backend does not support GLU op %s\n", ggml_glu_op_name(ggml_get_glu_op(op)));
             return false;
         }
-        if (has_view_op_input(op)) {
+        if (ggml_openvino_get_device_name() == "GPU" && has_view_op_input(op)) {
             // GGML_LOG_WARN("OpenVINO backend does not support unary op %s with view input\n",
             //               ggml_glu_op_name(ggml_get_glu_op(op)));
             return false;
@@ -1265,8 +1334,12 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
             return false;
         }
         if (ggml_is_quantized(src->type) && src->ne[2] != 1) {
-            // GGML_LOG_WARN("OpenVINO backend does not support 3D quantized tensors\n");
-            return false;
+            // 3D quantized tensors are only supported as MUL_MAT_ID expert weights
+            // (src[0]), which are dequantized per-expert in create_weight_node.
+            if (!(op->op == GGML_OP_MUL_MAT_ID && i == 0)) {
+                // GGML_LOG_WARN("OpenVINO backend does not support 3D quantized tensors\n");
+                return false;
+            }
         }
     }
 

--- a/ggml/src/ggml-openvino/ggml-quants.cpp
+++ b/ggml/src/ggml-openvino/ggml-quants.cpp
@@ -514,11 +514,28 @@ ov::Output<ov::Node> make_int8_weights(ov::Tensor & weight,
         auto weights_f16 = std::make_shared<ov::op::v0::Convert>(weights_node, ov::element::f16);
 
         if (use_bias && zp.get_size() > 0) {
-            // Bias path: w * s + b (zp tensor holds f16 bias values)
-            auto bias_f16 = std::make_shared<ov::op::v0::Constant>(zp);
-            auto w_s =
-                std::make_shared<ov::op::v1::Multiply>(weights_f16, scales_f16, ov::op::AutoBroadcastType::NUMPY);
-            result = std::make_shared<ov::op::v1::Add>(w_s, bias_f16, ov::op::AutoBroadcastType::NUMPY);
+            // Accurate dequant in the FUSABLE zero-point form: (w - zp) * s, where the
+            // zero point is an exact f16 value zp = -bias/scale (bias held in the zp
+            // tensor). This is algebraically equal to w*s + bias but, unlike an Add(bias)
+            // graph, it matches OpenVINO's ConvertGatherToGatherCompressed pattern
+            // (Constant->Convert->Subtract->Multiply), so MoE expert weights stay
+            // compressed through compile_model (no f32 materialization / OOM). Using a
+            // real f16 zp instead of an integer one avoids the round(min/scale) error
+            // that corrupts Q4_K/Q5_1 experts.
+            // Convert bias -> zero-point IN PLACE in the (buffer-backed) zp tensor to
+            // avoid allocating a duplicate f16 array.
+            auto * bias_zp_data = zp.data<ov::float16>();
+            const auto * scale_data = scales.data<ov::float16>();
+            size_t n = zp.get_size();
+            for (size_t i = 0; i < n; i++) {
+                float s = static_cast<float>(scale_data[i]);
+                float b = static_cast<float>(bias_zp_data[i]);
+                bias_zp_data[i] = ov::float16(s != 0.0f ? -b / s : 0.0f);
+            }
+            auto zero_point_f16 = std::make_shared<ov::op::v0::Constant>(zp);
+            auto w_zp =
+                std::make_shared<ov::op::v1::Subtract>(weights_f16, zero_point_f16, ov::op::AutoBroadcastType::NUMPY);
+            result = std::make_shared<ov::op::v1::Multiply>(w_zp, scales_f16, ov::op::AutoBroadcastType::NUMPY);
         } else {
             // Zero point path: (w - zp) * s
             auto zero_point = std::make_shared<ov::op::v0::Constant>(zp);
@@ -588,11 +605,24 @@ ov::Output<ov::Node> make_int4_weights(ov::Tensor & weight,
         auto weights_f16 = std::make_shared<ov::op::v0::Convert>(weights_node, ov::element::f16);
 
         if (use_bias && zp.get_size() > 0) {
-            // Bias path: w * s + b (zp tensor holds f16 bias values)
-            auto bias_f16 = std::make_shared<ov::op::v0::Constant>(zp);
-            auto w_s =
-                std::make_shared<ov::op::v1::Multiply>(weights_f16, scales_f16, ov::op::AutoBroadcastType::NUMPY);
-            result = std::make_shared<ov::op::v1::Add>(w_s, bias_f16, ov::op::AutoBroadcastType::NUMPY);
+            // Accurate dequant in the FUSABLE zero-point form: (w - zp) * s with an
+            // exact f16 zp = -bias/scale. Equivalent to w*s + bias but matches
+            // ConvertGatherToGatherCompressed so MoE experts stay compressed (no OOM),
+            // and avoids the round(min/scale) error of an integer zp.
+            // Convert bias -> zero-point IN PLACE in the zp tensor (which is backed by the
+            // backend buffer for experts) so we don't allocate a duplicate f16 array.
+            auto * bias_zp_data = zp.data<ov::float16>();
+            const auto * scale_data = scales.data<ov::float16>();
+            size_t n = zp.get_size();
+            for (size_t i = 0; i < n; i++) {
+                float s = static_cast<float>(scale_data[i]);
+                float b = static_cast<float>(bias_zp_data[i]);
+                bias_zp_data[i] = ov::float16(s != 0.0f ? -b / s : 0.0f);
+            }
+            auto zero_point_f16 = std::make_shared<ov::op::v0::Constant>(zp);
+            auto w_zp =
+                std::make_shared<ov::op::v1::Subtract>(weights_f16, zero_point_f16, ov::op::AutoBroadcastType::NUMPY);
+            result = std::make_shared<ov::op::v1::Multiply>(w_zp, scales_f16, ov::op::AutoBroadcastType::NUMPY);
         } else {
             // Zero point path: (w - zp) * s
             auto zero_points_node = std::make_shared<ov::op::v0::Constant>(zp);
@@ -739,7 +769,8 @@ std::shared_ptr<ov::Node> requantize_to_buffers(const ggml_tensor * tensor,
     return result;
 }
 
-OvWeight process_weight_tensor(const ggml_tensor * tensor, const void * data, void * output_base_ptr, bool use_bias) {
+OvWeight process_weight_tensor(const ggml_tensor * tensor, const void * data, void * output_base_ptr, bool use_bias,
+                               bool zp_buffer_is_f16) {
     GGML_ASSERT(tensor != nullptr);
     GGML_ASSERT(data != nullptr);
 
@@ -789,10 +820,15 @@ OvWeight process_weight_tensor(const ggml_tensor * tensor, const void * data, vo
     }
 
     if (use_bias) {
-        OPENVINO_ASSERT(!layout.is_requant,
-                        "use_bias is only used for test-backend-ops, which should not have requantization");
-        // bias node will be created on the fly and not use backend buffer
-        output_base_ptr = nullptr;
+        OPENVINO_ASSERT(!layout.is_requant, "use_bias cannot be combined with requantization");
+        // The f16 bias/zero-point can be written into the backend buffer ONLY when that
+        // buffer was sized for an f16 zp (caller sets zp_buffer_is_f16 - true for the 3D
+        // MoE expert set_tensor path, whose get_alloc_size reserves f16 zp space). For any
+        // other use_bias caller (e.g. test-backend-ops 2D weights, buffer sized for an
+        // integer zp) writing f16 zp would overflow it, so self-allocate instead.
+        if (!zp_buffer_is_f16) {
+            output_base_ptr = nullptr;
+        }
     }
 
     // F16 requant path - no separate scales/zp needed in result
@@ -821,7 +857,10 @@ OvWeight process_weight_tensor(const ggml_tensor * tensor, const void * data, vo
         result.weights = ov::Tensor(weight_type, node_shape, buf_base + layout.weights_offset);
         result.scales = ov::Tensor(ov::element::f16, scale_shape, buf_base + layout.scales_offset);
         if (!layout.is_symmetric) {
-            ov::element::Type zp_type = layout.is_u4 ? ov::element::u4 : ov::element::u8;
+            // use_bias stores an f16 bias in the zp slot (layout reserved f16-sized
+            // space); otherwise a packed integer zero-point.
+            ov::element::Type zp_type =
+                use_bias ? ov::element::f16 : (layout.is_u4 ? ov::element::u4 : ov::element::u8);
             result.zp = ov::Tensor(zp_type, scale_shape, buf_base + layout.zp_offset);
         }
         // else: result.zp remains default-constructed (empty) for symmetric

--- a/ggml/src/ggml-openvino/ggml-quants.h
+++ b/ggml/src/ggml-openvino/ggml-quants.h
@@ -126,7 +126,8 @@ OvWeight process_weight_tensor(
     const ggml_tensor * tensor,
     const void * data,                 // Source data pointer (may differ from tensor->data)
     void * output_base_ptr = nullptr,  // Base pointer for output buffers (or nullptr for internal allocation)
-    bool use_bias = false);            // Use fp bias instead of quantized zero_point, only used in test-backend-ops
+    bool use_bias = false,             // Use fp bias instead of quantized zero_point (test-backend-ops + 3D experts)
+    bool zp_buffer_is_f16 = false);    // output_base_ptr's zp slot is sized for f16 (3D-expert set_tensor path)
 
 void quantize_q4_0(const float * x,
                    ov::Tensor & weights_arr,

--- a/ggml/src/ggml-openvino/openvino/op/mul_mat_id.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/mul_mat_id.cpp
@@ -27,21 +27,23 @@ OutputVector translate_mul_mat_id(const NodeContext & context) {
     auto ids = process_view_input_new(context, 2);
 
     // OpenVINO sees GGML tensors in reversed dimension order:
-    //   weights: [1, n_expert, m, k]
     //   activations: [1, n_tokens, n_used_or_1, k]
     //   ids: [1, 1, n_tokens, n_used]
-    // Rebuild the logical ranks explicitly from the 4D inputs instead of relying
-    // on fixed squeeze axes: real graphs can arrive through VIEW/RESHAPE chains
-    // where singleton axes are still represented differently at this point.
-    auto expert_weights_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(expert_weights, ov::element::i64);
+    // The expert weights node is built specially in GgmlOvDecoder::create_weight_node
+    // as a rank-2 [n_expert, m*k] dequantization subgraph (Constant(u4)->Convert->
+    // [Subtract]->Multiply->Reshape(3D->2D)->Convert). We MUST gather experts directly
+    // on this rank-2 node so the CPU plugin can fold the Gather + dequant into a single
+    // GatherCompressed op (keeping the weights compressed and decompressing only the
+    // selected experts at runtime). Reshaping the weights to [n_expert,m,k] before the
+    // Gather would break that fusion and cause the plugin to materialize all experts as
+    // f32 at compile time → OOM. So we gather on [n_expert, m*k] and split m*k -> m,k on
+    // the gathered result afterwards.
     auto activations_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(activations, ov::element::i64);
     auto ids_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(ids, ov::element::i64);
 
-    auto expert_weights_shape_3d = get_dimensions(expert_weights_shape_4d, {1, 2, 3});
     auto activations_shape_3d = get_dimensions(activations_shape_4d, {1, 2, 3});
     auto ids_shape_2d = get_dimensions(ids_shape_4d, {2, 3});
 
-    expert_weights = std::make_shared<ov::op::v1::Reshape>(expert_weights, expert_weights_shape_3d, false);
     activations = std::make_shared<ov::op::v1::Reshape>(activations, activations_shape_3d, false);
     ids = std::make_shared<ov::op::v1::Reshape>(ids, ids_shape_2d, false);
 
@@ -49,13 +51,49 @@ OutputVector translate_mul_mat_id(const NodeContext & context) {
         ids = std::make_shared<ov::op::v0::Convert>(ids, ov::element::i32);
     }
 
+    // m (output row dim) is static; k = (m*k) / m. Gather experts on axis 0 of the
+    // rank-2 [n_expert, m*k] weight -> [n_tokens, n_used, m*k], then split to
+    // [n_tokens, n_used, m, k].
+    const auto output_type = context.get_output_type();
+    const auto mm_output_shape = context.get_output_shape();
+    FRONT_END_OP_CONVERSION_CHECK(mm_output_shape.rank().is_static() && mm_output_shape.rank().get_length() == 4,
+                                  "Unexpected MUL_MAT_ID output rank");
+    FRONT_END_OP_CONVERSION_CHECK(mm_output_shape[3].is_static(),
+                                  "Expected static row dimension (m) for MUL_MAT_ID output");
+    const int64_t m_value = mm_output_shape[3].get_length();
+
+    // Normalize the weight to rank-2 [n_expert, m*k] so the expert Gather sits on a
+    // 2D node (required for the GatherCompressed fusion). The quantized expert path in
+    // GgmlOvDecoder::create_weight_node already produces [n_expert, m*k]. The
+    // non-quantized path (f32/f16 experts, e.g. test-backend-ops) produces a rank-4
+    // [1, n_expert, m, k] constant; collapse it to [n_expert, m*k] here.
+    if (expert_weights.get_partial_shape().rank().is_static() &&
+        expert_weights.get_partial_shape().rank().get_length() != 2) {
+        auto w_shape = std::make_shared<ov::op::v3::ShapeOf>(expert_weights, ov::element::i64);
+        auto n_expert_dim = get_dimensions(w_shape, {1});
+        auto flat_w_dims = std::make_shared<ov::op::v0::Concat>(
+            ov::OutputVector{n_expert_dim, ov::op::v0::Constant::create(ov::element::i64, {1}, {-1})}, 0);
+        expert_weights = std::make_shared<ov::op::v1::Reshape>(expert_weights, flat_w_dims, false);
+    }
+
     auto gather_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
     ov::Output<ov::Node> selected_weights = std::make_shared<ov::op::v8::Gather>(expert_weights, ids, gather_axis);
 
-    const auto output_type = context.get_output_type();
     if (selected_weights.get_element_type() != ov::element::f32) {
         selected_weights = std::make_shared<ov::op::v0::Convert>(selected_weights, ov::element::f32);
     }
+
+    // Split the flattened m*k expert rows into [m, k]: reshape gathered
+    // [n_tokens, n_used, m*k] -> [n_tokens, n_used, m, -1].
+    auto sel_ids_shape = std::make_shared<ov::op::v3::ShapeOf>(ids, ov::element::i64);
+    auto split_target_dims = std::make_shared<ov::op::v0::Concat>(
+        ov::OutputVector{
+            get_dimensions(sel_ids_shape, {0, 1}),
+            ov::op::v0::Constant::create(ov::element::i64, {1}, {m_value}),
+            ov::op::v0::Constant::create(ov::element::i64, {1}, {-1}),
+        },
+        0);
+    selected_weights = std::make_shared<ov::op::v1::Reshape>(selected_weights, split_target_dims, false);
     if (activations.get_element_type() != ov::element::f32) {
         activations = std::make_shared<ov::op::v0::Convert>(activations, ov::element::f32);
     }
@@ -69,19 +107,14 @@ OutputVector translate_mul_mat_id(const NodeContext & context) {
             get_dimensions(activations_shape, {2}),
         },
         0);
-    ov::Output<ov::Node> acts_broadcasted =
-        std::make_shared<ov::op::v3::Broadcast>(activations, acts_target_dims, ov::op::BroadcastType::BIDIRECTIONAL);
+    ov::Output<ov::Node> acts_broadcasted = std::make_shared<ov::op::v3::Broadcast>(activations, acts_target_dims,
+                                                                                     ov::op::BroadcastType::BIDIRECTIONAL);
 
     auto unsqueeze_axes = ov::op::v0::Constant::create(ov::element::i64, {1}, {2});
     auto activations_expanded = std::make_shared<ov::op::v0::Unsqueeze>(acts_broadcasted, unsqueeze_axes);
 
     auto batch_dim = ov::op::v0::Constant::create(ov::element::i64, {1}, {1});
-    auto output_shape = context.get_output_shape();
-    FRONT_END_OP_CONVERSION_CHECK(output_shape.rank().is_static() && output_shape.rank().get_length() == 4,
-                                  "Unexpected MUL_MAT_ID output rank");
-    FRONT_END_OP_CONVERSION_CHECK(output_shape[3].is_static(), "Expected static row dimension for MUL_MAT_ID output");
-    const auto row_dim_value = output_shape[3].get_length();
-    auto row_dim = ov::op::v0::Constant::create(ov::element::i64, {1}, {row_dim_value});
+    auto row_dim = ov::op::v0::Constant::create(ov::element::i64, {1}, {m_value});
 
     ov::Output<ov::Node> result =
         std::make_shared<ov::op::v0::MatMul>(activations_expanded, selected_weights, false, true);

--- a/ggml/src/ggml-openvino/openvino/op/view.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/view.cpp
@@ -1,11 +1,9 @@
 #include "../op_table.h"
 #include "../utils.h"
-
 #include <openvino/op/constant.hpp>
 #include <openvino/op/reshape.hpp>
 #include <openvino/op/slice.hpp>
 #include <set>
-
 namespace ov {
 namespace frontend {
 namespace ggml {
@@ -15,6 +13,73 @@ OutputVector translate_view(const NodeContext & context) {
     num_inputs_check(context, 1, 1);
 
     if (!context.is_static()) {
+        // On the stateless/non-static path VIEW is normally a no-op (consumers re-slice).
+        // EXCEPTION: the MoE expert aggregation slices each expert plane out of
+        // ffn_moe_weighted [n_embd, n_expert_used, n_tokens] with ggml_view_2d and then
+        // sums the planes with a chain of ADDs (llama-graph.cpp). Those ADDs read this
+        // VIEW node directly from the tensor map and do NOT re-slice, so a no-op here
+        // makes every plane the full tensor and the expert sum collapses. Materialize the
+        // single-expert slice here. Gated by name (ffn_moe_weighted...view) so it can't
+        // affect any other view.
+        const std::string & vname = context.get_name();
+        if (vname.find("ffn_moe_weighted") != std::string::npos) {
+            auto src_ps = context.get_input_shape(0);
+            auto dst_ps = context.get_output_shape();
+            if (src_ps.rank().is_static() && dst_ps.rank().is_static() && src_ps.rank() == dst_ps.rank() &&
+                src_ps.is_static() && dst_ps.is_static()) {
+                auto sst = context.get_input_stride(0);
+                auto dst = context.get_output_stride();
+                size_t voff = context.get_output_op_offset();
+                auto ss = src_ps.to_shape();
+                auto dd = dst_ps.to_shape();
+                const size_t nd = ss.size();
+                if (sst.size() == nd && dst.size() == nd) {
+                    // Map each dst axis of size>1 to a src axis with equal (size,stride);
+                    // the unmatched src axis of size>1 is the indexed expert axis.
+                    std::vector<bool> used(nd, false);
+                    bool ok = true;
+                    for (size_t d = 0; d < nd; ++d) {
+                        if (dd[d] == 1) {
+                            continue;
+                        }
+                        int found = -1;
+                        for (size_t s = 0; s < nd; ++s) {
+                            if (!used[s] && ss[s] == dd[d] && sst[s] == dst[d]) { found = (int) s; break; }
+                        }
+                        if (found < 0) { ok = false; break; }
+                        used[found] = true;
+                    }
+                    int dropped = -1;
+                    if (ok) {
+                        for (size_t s = 0; s < nd; ++s) {
+                            if (!used[s] && ss[s] > 1) {
+                                if (dropped >= 0) { ok = false; break; }
+                                dropped = (int) s;
+                            }
+                        }
+                    }
+                    if (ok && dropped >= 0) {
+                        const size_t dstr = sst[dropped];
+                        const int64_t dsz = (int64_t) ss[dropped];
+                        if (dstr > 0 && voff % dstr == 0) {
+                            const int64_t sel = (int64_t) (voff / dstr);
+                            if (sel >= 0 && sel < dsz) {
+                                ov::Output<ov::Node> sl = std::make_shared<ov::op::v8::Slice>(
+                                    context.get_input(0),
+                                    ov::op::v0::Constant::create(ov::element::i64, {1}, {sel}),
+                                    ov::op::v0::Constant::create(ov::element::i64, {1}, {sel + 1}),
+                                    ov::op::v0::Constant::create(ov::element::i64, {1}, {1}),
+                                    ov::op::v0::Constant::create(ov::element::i64, {1}, {dropped}));
+                                auto dc = ov::op::v0::Constant::create(
+                                    ov::element::i64, {nd}, std::vector<int64_t>(dd.begin(), dd.end()));
+                                auto rs = std::make_shared<ov::op::v1::Reshape>(sl, dc, false);
+                                return rename_outputs_with_suffix({rs}, context.get_name());
+                            }
+                        }
+                    }
+                }
+            }
+        }
         return {context.get_input(0)};
     }
 
@@ -28,15 +93,11 @@ OutputVector translate_view(const NodeContext & context) {
 
     int64_t src_elems = 1, dst_elems = 1;
     for (int64_t i = 0; i < src_shape.rank().get_length(); ++i) {
-        if (src_shape[i].is_dynamic()) {
-            return {input};
-        }
+        if (src_shape[i].is_dynamic()) return {input};
         src_elems *= src_shape[i].get_length();
     }
     for (int64_t i = 0; i < dst_shape.rank().get_length(); ++i) {
-        if (dst_shape[i].is_dynamic()) {
-            return {input};
-        }
+        if (dst_shape[i].is_dynamic()) return {input};
         dst_elems *= dst_shape[i].get_length();
     }
 
@@ -88,9 +149,7 @@ OutputVector translate_view(const NodeContext & context) {
         ov_stride_for_dim *= src_ov_shape[i];
     }
     size_t elem_size = src_stride.back();
-    if (elem_size == 0) {
-        elem_size = 1;
-    }
+    if (elem_size == 0) elem_size = 1;
 
     int64_t begin_val = 0;
     if (ov_stride_for_dim > 0 && elem_size > 0) {
@@ -102,11 +161,12 @@ OutputVector translate_view(const NodeContext & context) {
         return {input};
     }
 
-    auto sliced =
-        std::make_shared<ov::op::v8::Slice>(input, ov::op::v0::Constant::create(ov::element::i64, {1}, {begin_val}),
-                                            ov::op::v0::Constant::create(ov::element::i64, {1}, {end_val}),
-                                            ov::op::v0::Constant::create(ov::element::i64, {1}, {1}),
-                                            ov::op::v0::Constant::create(ov::element::i64, {1}, {slice_dim}));
+    auto sliced = std::make_shared<ov::op::v8::Slice>(
+        input,
+        ov::op::v0::Constant::create(ov::element::i64, {1}, {begin_val}),
+        ov::op::v0::Constant::create(ov::element::i64, {1}, {end_val}),
+        ov::op::v0::Constant::create(ov::element::i64, {1}, {1}),
+        ov::op::v0::Constant::create(ov::element::i64, {1}, {slice_dim}));
 
     sliced->set_friendly_name(context.get_output_name());
     return {sliced->output(0)};


### PR DESCRIPTION
[DO NOT MERGE YET - WAITING FOR: https://github.com/ggml-org/llama.cpp/pull/24503]

    Enable the Gemma-4 26B-A4B hybrid MoE model on the OpenVINO CPU path.
    Minimal change set on top of dev_backend_openvino, leaving the existing
    non-MoE work (ADD_ID, flash-attn, gated_delta_net, rope, ssm_conv, the
    getenv helpers, and the table-driven supports_op) untouched.
    
    - ggml-quants: dequantize 3D expert weights in the fusable zero-point form
      (w - zp) * s with an exact f16 zp = -bias/scale, written in place into the
      zp buffer. Matches ConvertGatherToGatherCompressed so experts stay
      compressed through compile_model (no ~87GB f32 materialization / OOM) and
      avoids the round(min/scale) error that corrupted Q4_K/Q5_1 experts. Add a
      zp_buffer_is_f16 flag so only the 3D-expert path writes f16 zp into a
      buffer sized for it.
    - ggml-openvino-extra: extract 3D MoE expert weights [k, m, n_expert] as a
      flattened 2D tensor, size the zp slot for f16 under use_bias, and keep
      token_embd native (un-requantized) on CPU/GPU for accuracy.
    - ggml-openvino: flatten/extract 3D expert weights in set_tensor and
      get_alloc_size; gate the MoE routing ops to CPU only on GPU (they are
      stable on the CPU device); allow 3D quantized MUL_MAT_ID src[0].
    - ggml-decoder: build the rank-2 expert dequant node in create_weight_node
      and give each VIEW a unique tensor_map key to avoid per-expert collisions.
    - mul_mat_id / view: gather experts on the rank-2 weight axis and slice the
      per-expert view.