### PR TITLE
OpenVINO backend: fix accuracy issue for op CONCAT with i64 precision

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -884,6 +884,12 @@ static bool mul_mat_id_requires_large_tmp(const ggml_tensor * op) {
 
 static bool is_op_unsupported_case(const ggml_tensor * op) {
     switch (op->op) {
+    case GGML_OP_CONCAT: {
+        if (op->type == GGML_TYPE_I64) {
+            return true;
+        }
+        break;
+    }
     case GGML_OP_GET_ROWS:
     case GGML_OP_SET_ROWS: {
         if (op->ne[3] != 1) {


### PR DESCRIPTION
This pull request updates the logic for detecting unsupported operations in the OpenVINO backend. The main change is to explicitly mark `GGML_OP_CONCAT` with type `GGML_TYPE_I64` as unsupported, which will help prevent errors during model execution.

Operation support updates:

* Updated `is_op_unsupported_case` to return `true` for `GGML_OP_CONCAT` operations when the tensor type is `GGML_TYPE_I64`, ensuring these cases are properly flagged as unsupported.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
