### PR TITLE
Disable EXP for FP32 in OpenVINO backend due to overflow issue

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -1236,6 +1236,9 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
             // GGML_LOG_WARN("OpenVINO backend does not support unary op %s\n", ggml_unary_op_name(ggml_get_unary_op(op)));
             return false;
         }
+        if (ggml_get_unary_op(op) == GGML_UNARY_OP_EXP && op->type == GGML_TYPE_F32) {
+            return false;
+        }
         break;
     }
     case GGML_OP_GLU: {


### PR DESCRIPTION
This pull request introduces a targeted update to the OpenVINO backend device support logic. It specifically ensures that the backend no longer claims to support the `EXP` unary operation for 32-bit floating point (`F32`) types, likely to address incorrect behavior or lack of support for this operation-type combination.

**OpenVINO backend operation support update:**

* Updated `ggml_backend_openvino_device_supports_op` in `ggml-openvino.cpp` to explicitly return `false` for the `EXP` unary operation when the operand type is `F32`, preventing unsupported operation usage.…t reason: the backend test initializes unary op inputs over a wide range, [-150, 150]. For FP32, exp(x) overflows around x ~= 88.7, so this test can randomly generate values right in or beyond the overflow region

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
