### PR TITLE
OpenVINO backend: fix CPY op test failed issue

### DIFF
--- a/ggml/src/ggml-openvino/openvino/op/cpy.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/cpy.cpp
@@ -52,6 +52,11 @@ OutputVector translate_cpy(const NodeContext & context) {
     } else {
         res = input;
     }
+
+    if (res.get_node_shared_ptr() == context.get_input(0).get_node_shared_ptr()) {
+        return {res};
+    }
+
     return rename_outputs_with_suffix({res}, context.get_name());
 }
 


### PR DESCRIPTION
This pull request makes a targeted change to the `translate_cpy` function in `ggml/src/ggml-openvino/openvino/op/cpy.cpp` to optimize output handling. The update adds a condition to immediately return the result if it shares the same node pointer as the input, avoiding unnecessary renaming operations.

Optimization of output handling:

* Updated `translate_cpy` to check if the output node is identical to the input node, and if so, return early without renaming outputs.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
[Copilot is generating a summary...]