### PR TITLE
OpenVINO Backenb: remove changes in llama.cpp

### DIFF
--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -695,9 +695,7 @@ extern "C" {
 
         void * extra; // extra things e.g. for ggml-cuda.cu
 
-        char padding[16];
-        // add a struct ggml_tensor * named org_src, initialized to NULL, for keeping track of original source tensors in case of in-place operations
-        struct ggml_tensor * org_src;
+        char padding[8];
     };
 
     static const size_t GGML_TENSOR_SIZE = sizeof(struct ggml_tensor);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1360,7 +1360,6 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
                                 ggml_set_input(tensor_copy);
                                 ggml_set_output(tensor_copy); // prevent ggml-alloc from overwriting the tensor
                             }
-                            tensor_copy->org_src = src;
                             tensor_id_copy(src_id, cur_backend_id, c) = tensor_copy;
                             SET_CAUSE(tensor_copy, "4.cpy");
                         }

--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -1481,10 +1481,10 @@ void GgmlOvDecoder::compute_node_dynamic_dims() {
             if (src == nullptr) {
                 continue;
             }
-            ggml_tensor * root_src = nullptr;
-            if (src->org_src) {
-                root_src = src->org_src;
-            }
+            struct ggml_tensor * root_src = nullptr;
+            // if (src->org_src) {
+            //     root_src = src->org_src;
+            // }
             if (root_src) {
                 if (is_inp_tok(root_src, node) || is_inp_pos(root_src, node) || is_output_idx(root_src, node)) {
                     m_node_dynamic_dims[root_src] = 0;
@@ -1562,7 +1562,7 @@ void GgmlOvDecoder::compute_node_dynamic_dims() {
             // identifies the dynamic dim even when two dims share the same size.
             m_node_dynamic_dims[node] = -1;
             if (m_node_dynamic_dims[node->src[0]] != -1) {
-                if (node->src[0]->op == GGML_OP_NONE && node->src[0]->org_src == nullptr) {
+                if (node->src[0]->op == GGML_OP_NONE) {
                     m_node_dynamic_dims[node] = m_node_dynamic_dims[node->src[0]];
                     break;
                 }

--- a/ggml/src/ggml-openvino/ggml-decoder.h
+++ b/ggml/src/ggml-openvino/ggml-decoder.h
@@ -303,7 +303,7 @@ public:
     void update_io(ggml_cgraph * cgraph);
 
     inline static bool is_inp_tok(const ggml_tensor * tensor, const ggml_tensor * op) {
-        return op->op == GGML_OP_GET_ROWS && tensor == op->src[1] && op->src[0]->op == GGML_OP_NONE && op->src[0]->org_src == nullptr;
+        return op->op == GGML_OP_GET_ROWS && tensor == op->src[1] && op->src[0]->op == GGML_OP_NONE;
     }
 
     inline static bool is_inp_pos(const ggml_tensor * tensor, const ggml_tensor * op) {

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1781,7 +1781,6 @@ static struct ggml_tensor * ggml_new_tensor_impl(
         /*.name         =*/ { 0 },
         /*.extra        =*/ NULL,
         /*.padding      =*/ { 0 },
-        /*.org_src       =*/ NULL,
     };
 
     // TODO: this should not be needed as long as we don't rely on aligned SIMD loads


### PR DESCRIPTION
This pull request removes the `org_src` member from the `ggml_tensor` struct and updates all related logic throughout the codebase. This change simplifies the tensor structure and removes checks and assignments related to `org_src` in both the OpenVINO decoder and backend scheduling code.

**Tensor structure simplification:**

* Removed the `org_src` pointer from the `ggml_tensor` struct in `ggml.h`, reducing the size of the `padding` array accordingly.
* Updated the tensor initialization in `ggml.c` to remove the initialization of `org_src`.

**Code cleanup and logic updates:**

* Removed all assignments to and checks for `org_src` in backend scheduling logic in `ggml-backend.cpp`.
* Updated the OpenVINO decoder (`ggml-decoder.cpp` and `ggml-decoder.h`) to remove logic that referenced or depended on `org_src`, simplifying conditions and removing unused code. [[1]](diffhunk://#diff-eafa32f3b7b0ba782711f9188ab1b9687264c80b7edf7a1d5d04c77c9ff191aeL1484-R1487) [[2]](diffhunk://#diff-eafa32f3b7b0ba782711f9188ab1b9687264c80b7edf7a1d5d04c77c9ff191aeL1565-R1565) [[3]](diffhunk://#diff-e0fb1e316593457e151c376b0c6b538e0259e3e4d255f405ad8d221240c7405dL306-R306)

These changes reduce complexity and potential confusion around tensor source tracking, making the codebase easier to maintain.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
