### PR TITLE
Doc change (use x64 Native Tools Command Prompt for VS)

### DIFF
--- a/docs/backend/OPENVINO.md
+++ b/docs/backend/OPENVINO.md
@@ -206,7 +206,7 @@ cmake -B build/ReleaseOV -G Ninja -DCMAKE_BUILD_TYPE=Release -DGGML_OPENVINO=ON
 cmake --build build/ReleaseOV --parallel
 ```
 
-- **Windows:** Open a **Developer Command Prompt for VS 2022** (so the MSVC toolchain is on `PATH`), then run:
+- **Windows:** Open a **x64 Native Tools Command Prompt for VS** (so the MSVC toolchain is on `PATH`), then run:
 
 ```cmd
 C:\Intel\openvino\setupvars.bat

--- a/docs/backend/OPENVINO.md
+++ b/docs/backend/OPENVINO.md
@@ -206,7 +206,7 @@ cmake -B build/ReleaseOV -G Ninja -DCMAKE_BUILD_TYPE=Release -DGGML_OPENVINO=ON
 cmake --build build/ReleaseOV --parallel
 ```
 
-- **Windows:** Open a **x64 Native Tools Command Prompt for VS** (so the MSVC toolchain is on `PATH`), then run:
+- **Windows:** Open **x64 Native Tools Command Prompt for VS** (so the MSVC toolchain is on `PATH`), then run:
 
 ```cmd
 C:\Intel\openvino\setupvars.bat


### PR DESCRIPTION
Tried building on Windows (VS 2026) using the documentation. It suggests to use "Developer Command Prompt for VS 2022", but that specific terminal uses x86 (32 bit compiler and toolchain) and while building, cmake is unable to find a proper TBB package from setupvars path (TBB included in OpenVINO is 64 bit, so it disregards it).

<img width="1560" height="534" alt="image" src="https://github.com/user-attachments/assets/4aeeb079-180e-4cc1-b6d6-d7244e1a8724" />

Using "x64 Native Tools Command Prompt for VS" uses the 64 bit compiler and toolchain from VS products, so cmake successfully finds TBB 64-bit package and the build process completes successfully.

<img width="1205" height="611" alt="image" src="https://github.com/user-attachments/assets/e3656c37-92fd-408a-bbda-3f2cc60a3f46" />

So I propose to change this line in the documentation.