### PR TITLE
Enable Llama architecture tests in CI for OpenVINO backend

### DIFF
--- a/.github/workflows/build-openvino.yml
+++ b/.github/workflows/build-openvino.yml
@@ -78,18 +78,16 @@ jobs:
 
       - name: Test (CPU)
         id: cmake_test_cpu
-        # TODO: fix and re-enable the `test-llama-archs` test below
         run: |
           cd ${{ github.workspace }}
-          ctest --test-dir build/ReleaseOV -L main -E "test-llama-archs" --verbose --timeout 2000
+          ctest --test-dir build/ReleaseOV -L main --verbose --timeout 2000
 
       - name: Test (GPU)
         id: cmake_test_gpu
-        # TODO: fix and re-enable the `test-llama-archs` test below
         run: |
           cd ${{ github.workspace }}
           export GGML_OPENVINO_DEVICE=GPU
-          ctest --test-dir build/ReleaseOV -L main -E "test-llama-archs" --verbose --timeout 3000
+          ctest --test-dir build/ReleaseOV -L main --verbose --timeout 3000
 
   openvino-windows-2022:
     runs-on: windows-2022
@@ -159,11 +157,10 @@ jobs:
       - name: Test (CPU)
         id: cmake_test_cpu
         shell: cmd
-        # TODO: fix and re-enable the `test-llama-archs` test below
         run: |
           REM Find extracted OpenVINO folder dynamically
           for /d %%i in (openvino_toolkit\*) do set OPENVINO_ROOT=%%i
           call "%OPENVINO_ROOT%\setupvars.bat"
 
           cd build
-          ctest --test-dir ReleaseOV -L main -E "test-llama-archs" -C Release --verbose --timeout 3000
+          ctest --test-dir ReleaseOV -L main -C Release --verbose --timeout 3000


### PR DESCRIPTION
This pull request updates the `.github/workflows/build-openvino.yml` workflow to re-enable the `test-llama-archs` test during the CPU and GPU test steps on both Linux and Windows platforms. This is done by removing the exclusion flag from the `ctest` commands.

**Workflow and Testing Updates:**

* The exclusion of the `test-llama-archs` test has been removed from the `ctest` commands for both CPU and GPU test steps, ensuring that all main tests are now executed as part of the CI process. [[1]](diffhunk://#diff-26e574b0e1612b5a76fb795e4b3bb24fd45dcfe449a478e1f7d612189222819aL81-R90) [[2]](diffhunk://#diff-26e574b0e1612b5a76fb795e4b3bb24fd45dcfe449a478e1f7d612189222819aL162-R166)
* Outdated comments referencing the need to fix and re-enable the `test-llama-archs` test have been deleted, reflecting that the test is now included. [[1]](diffhunk://#diff-26e574b0e1612b5a76fb795e4b3bb24fd45dcfe449a478e1f7d612189222819aL81-R90) [[2]](diffhunk://#diff-26e574b0e1612b5a76fb795e4b3bb24fd45dcfe449a478e1f7d612189222819aL162-R166)## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
