### PR TITLE
qwen35 moe

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -575,7 +575,7 @@ std::pair<ModelParams, ComputeParams> GgmlOvDecoder::compute_llm_params(ggml_cgr
         if (node->op == GGML_OP_GATED_DELTA_NET) {
             model_params.state_size = node->src[0]->ne[0];
         }
-        if (node->op == GGML_OP_SCALE && is_kvcache(node->view_src, nullptr)) {
+        if (node->op == GGML_OP_SCALE && node->view_src != nullptr && is_kvcache(node->view_src, nullptr)) {
             compute_params.cache_rs_reset_len = ggml_nelements(node) / node->view_src->ne[0];
             compute_params.cache_rs_reset_idx = node->src[0]->view_offs / node->view_src->ne[0];
         }
@@ -915,6 +915,16 @@ std::map<std::string, std::string> GgmlOvDecoder::get_kv_param_res_names() const
     return kv_param_res_names;
 }
 
+// MUL_MAT_ID's src[0] is the [k, m, n_expert] expert-weight tensor. It is always a constant per-expert
+// weight table -- never a computed activation -- regardless of whether the backend happened to mark its
+// buffer as GGML_BACKEND_BUFFER_USAGE_WEIGHTS (test-backend-ops, for example, never sets that usage
+// flag, unlike real inference). Without this, non-quantized (F16/F32/BF16) expert weights would fall
+// through the check below as "not a weight", get decoded as a Parameter/activation instead of a
+// Constant, and crash GatherMatmul's "only constant weights are supported" check.
+static bool is_mul_mat_id_expert_weight(const ggml_tensor * node, int src_index) {
+    return node->op == GGML_OP_MUL_MAT_ID && src_index == 0;
+}
+
 std::map<std::string, std::shared_ptr<ov::Node>> GgmlOvDecoder::create_weight_nodes(ggml_cgraph * cgraph, bool naive) {
     std::map<std::string, std::shared_ptr<ov::Node>> model_weights;
     auto * nodes = cgraph->nodes;
@@ -933,7 +943,8 @@ std::map<std::string, std::shared_ptr<ov::Node>> GgmlOvDecoder::create_weight_no
             }
             if (!src->view_src) {
                 ggml_backend_buffer * buffer = src->buffer;
-                if (buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS || ggml_is_quantized(src->type)) {
+                if (buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS || ggml_is_quantized(src->type) ||
+                    is_mul_mat_id_expert_weight(node, i)) {
                     if (model_weights.find(src_name) == model_weights.end()) {
                         auto weight_node = create_weight_node(src, naive);
                         weight_node->set_friendly_name(src_name);
@@ -1700,7 +1711,21 @@ void GgmlOvDecoder::compute_node_dynamic_dims() {
         case GGML_OP_DIAG:
         case GGML_OP_TRI:
         case GGML_OP_REPEAT:
+        // Shape-preserving elementwise ops: the dynamic dim is unchanged from src[0].
+        // DIV/CLAMP are used in the MoE routing-weight normalization
+        // (sum_rows -> clamp -> div). If they are left untracked here the dynamic
+        // (token) dim is lost there, the captured prefill token count gets baked into
+        // the downstream reshapes, and every decoder layer after layer 0 turns static
+        // (which then triggers the GPU in-place-concat KV-cache corruption).
+        case GGML_OP_DIV:
+        case GGML_OP_CLAMP:
             m_node_dynamic_dims[node] = m_node_dynamic_dims[node->src[0]];
+            break;
+        case GGML_OP_SUM_ROWS:
+            // SUM_ROWS reduces ggml axis 0 to size 1 and preserves all other axes, so the
+            // dynamic dim is preserved unless it was axis 0 (then it is summed away).
+            m_node_dynamic_dims[node] =
+                (m_node_dynamic_dims[node->src[0]] == 0) ? -1 : m_node_dynamic_dims[node->src[0]];
             break;
         case GGML_OP_MUL_MAT_ID:
         case GGML_OP_SOLVE_TRI:

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
@@ -252,11 +252,18 @@ ggml_openvino_extracted_layout ggml_openvino_get_extracted_layout(const ggml_ten
         return layout;
     }
 
-    // Most quantized weights use the existing 2D extraction path. MXFP4 also
-    // appears as 3D expert weights for MUL_MAT_ID, so allow that type through.
-    if (tensor->type != GGML_TYPE_MXFP4 && (tensor->ne[2] != 1 || tensor->ne[3] != 1)) {
+    // Most quantized weights use the existing 2D extraction path. 3D expert weights for
+    // MUL_MAT_ID (MoE) are also supported, either as MXFP4 (packed, dedicated branch below) or via the
+    // generic sizing math below, which is shape-agnostic (based on total element count). Only reject 4D.
+    if (tensor->ne[3] != 1) {
         return layout;
     }
+
+    // 3D MoE expert weights that are not requantized (see below) always use the exact f16
+    // zero-point extraction (see extract_quantized_weights), which needs a wider zp slot than
+    // the packed integer zero point -- must be kept in sync with that function so the buffer
+    // sizing here matches what process_weight_tensor actually writes.
+    const bool for_gather_matmul = tensor->ne[2] > 1;
 
     int64_t n_elements = ggml_nelements(tensor);
     const size_t alignment = 64;  // Good for SIMD
@@ -387,9 +394,14 @@ ggml_openvino_extracted_layout ggml_openvino_get_extracted_layout(const ggml_ten
     // Scales: F16 per block, except MXFP4 which stores one E8M0 byte per block.
     int64_t n_blocks = n_elements / layout.weights_per_block;
     layout.scales_size = n_blocks * (tensor->type == GGML_TYPE_MXFP4 ? sizeof(uint8_t) : sizeof(uint16_t));
-    // For symmetric quantization, no zp needed (weights stored as signed)
+    // For symmetric quantization, no zp needed (weights stored as signed). Asymmetric
+    // for_gather_matmul (3D MoE expert) weights use an exact f16 zero point (see
+    // extract_quantized_weights/make_int8_weights/make_int4_weights), which needs one f16 per
+    // block instead of a packed u4/u8 integer zero point.
     if (layout.is_symmetric) {
         layout.zp_size = 0;
+    } else if (use_bias || for_gather_matmul) {
+        layout.zp_size = n_blocks * sizeof(uint16_t);
     } else {
         layout.zp_size = layout.is_u4 ? ((n_blocks + 1) / 2) : n_blocks;
     }

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -235,9 +235,10 @@ static void ggml_backend_openvino_buffer_set_tensor(ggml_backend_buffer_t buffer
     bool is_weight_buffer = (buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
     // Full tensor set: offset=0, full size, not a view
     bool is_full_tensor_set = (offset == 0 && size == ggml_nbytes(tensor) && tensor->view_src == nullptr);
-    // 2D tensor (typical weight shape)
+    // 2D tensor (typical weight shape), or a 3D quantized MoE expert weight (MUL_MAT_ID). Dense 3D
+    // expert weights are handled later in create_weight_node instead.
     bool is_2d = (tensor->ne[2] == 1 && tensor->ne[3] == 1);
-    bool is_supported_weight_shape = is_2d || tensor->type == GGML_TYPE_MXFP4;
+    bool is_supported_weight_shape = is_2d || (tensor->ne[3] == 1 && ggml_is_quantized(tensor->type));
 
     if (is_weight_buffer && is_full_tensor_set && is_supported_weight_shape) {
         try {
@@ -460,8 +461,7 @@ static size_t ggml_backend_openvino_buffer_type_get_alloc_size(ggml_backend_buff
     GGML_UNUSED(buft);
 
     // For quantized weight tensors, we need extra space for extracted data.
-    if (ggml_is_quantized(tensor->type) &&
-        ((tensor->ne[2] == 1 && tensor->ne[3] == 1) || tensor->type == GGML_TYPE_MXFP4)) {
+    if (ggml_is_quantized(tensor->type) && tensor->ne[3] == 1) {
         ggml_openvino_extracted_layout layout = ggml_openvino_get_extracted_layout(tensor);
         if (layout.total_size > 0) {
             // GGML_LOG_DEBUG("%s: tensor %s needs %zu bytes (original %zu, extracted: weights=%zu scales=%zu zp=%zu)\n",
@@ -890,9 +890,10 @@ static bool mul_mat_id_requires_large_tmp(const ggml_tensor * op) {
         return true;
     }
 
-    // The current OpenVINO translation materializes selected expert weights with
-    // shape [n_tokens, n_used, rows, k]. Skip cases that would create a very
-    // large temporary on GPU and let the scheduler fall back instead.
+    // The MXFP4 MUL_MAT_ID translation (translate_mul_mat_id_mxfp4_packed in mul_mat_id.cpp)
+    // materializes selected expert weights with shape [n_tokens, n_used, rows, k]. Skip cases that
+    // would create a very large temporary and let the scheduler fall back instead. Every other weight
+    // type goes through GatherMatmul, which never materializes this temporary.
     size_t tmp_elems = 1;
     if (!checked_mul_size(tmp_elems, static_cast<size_t>(ids->ne[1]), tmp_elems) ||
         !checked_mul_size(tmp_elems, static_cast<size_t>(ids->ne[0]), tmp_elems) ||
@@ -1068,11 +1069,16 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         break;
     }
     case GGML_OP_MUL_MAT_ID: {
+        // Single-expert (or empty) MUL_MAT_ID is a degenerate shape that stresses GatherMatmul edge
+        // cases and never occurs in real MoE; let it fall back to CPU.
+        if (op->src[0] != nullptr && op->src[0]->ne[2] <= 1) {
+            return true;
+        }
         if (ggml_openvino_get_device_name() == "GPU" && op->src[0] != nullptr && op->src[0]->type == GGML_TYPE_BF16) {
             return true;
         }
-        if (mul_mat_id_requires_large_tmp(op) &&
-            !(op->src[0] != nullptr && op->src[0]->type == GGML_TYPE_MXFP4)) {
+        // Only MXFP4 materializes a large per-token temporary; all other types use GatherMatmul.
+        if (op->src[0] != nullptr && op->src[0]->type == GGML_TYPE_MXFP4 && mul_mat_id_requires_large_tmp(op)) {
             return true;
         }
         break;
@@ -1231,11 +1237,11 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
             // GGML_LOG_WARN("OpenVINO backend does not support GLU op %s\n", ggml_glu_op_name(ggml_get_glu_op(op)));
             return false;
         }
-        if (has_view_op_input(op)) {
-            // GGML_LOG_WARN("OpenVINO backend does not support unary op %s with view input\n",
-            //               ggml_glu_op_name(ggml_get_glu_op(op)));
-            return false;
-        }
+        // if (has_view_op_input(op)) {
+        //     // GGML_LOG_WARN("OpenVINO backend does not support unary op %s with view input\n",
+        //     //               ggml_glu_op_name(ggml_get_glu_op(op)));
+        //     return false;
+        // }
         if (op->src[1] == nullptr && op->src[0]->ne[0] % 2 != 0) {
             // triggers bug in ov gpu
             return false;
@@ -1269,9 +1275,9 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
             // GGML_LOG_WARN("OpenVINO backend does not support tensor type %s\n", ggml_type_name(src->type));
             return false;
         }
-        const bool is_supported_3d_mxfp4_moe = op->op == GGML_OP_MUL_MAT_ID && i == 0 &&
-                                               src->type == GGML_TYPE_MXFP4;
-        if (ggml_is_quantized(src->type) && src->ne[2] != 1 && !is_supported_3d_mxfp4_moe) {
+        const bool is_supported_3d_moe_expert =
+            op->op == GGML_OP_MUL_MAT_ID && i == 0 && (src->type == GGML_TYPE_MXFP4 || src->ne[3] == 1);
+        if (ggml_is_quantized(src->type) && src->ne[2] != 1 && !is_supported_3d_moe_expert) {
             // GGML_LOG_WARN("OpenVINO backend does not support 3D quantized tensors\n");
             return false;
         }

--- a/ggml/src/ggml-openvino/ggml-quants.cpp
+++ b/ggml/src/ggml-openvino/ggml-quants.cpp
@@ -18,8 +18,8 @@
 #include <openvino/core/shape.hpp>
 #include <openvino/core/type/element_type.hpp>
 #include <openvino/core/type/element_type_traits.hpp>
-#include <openvino/core/type/float4_e2m1.hpp>
 #include <openvino/core/type/float16.hpp>
+#include <openvino/core/type/float4_e2m1.hpp>
 #include <openvino/core/type/float8_e8m0.hpp>
 #include <openvino/op/add.hpp>
 #include <openvino/op/constant.hpp>
@@ -28,6 +28,7 @@
 #include <openvino/op/reshape.hpp>
 #include <openvino/op/subtract.hpp>
 #include <openvino/op/util/attr_types.hpp>
+#include <openvino/pass/constant_folding.hpp>
 #include <openvino/runtime/tensor.hpp>
 #include <string>
 #include <vector>
@@ -504,22 +505,34 @@ void extract_q5_k_data(const ggml_tensor * tensor,
 
 // TODO Reorder for make_intX_weights
 
+// If for_gather_matmul is true, weight may be N-D (e.g. 3D MoE expert weights [n_expert, rows, cols]).
+// The dequantization chain below is built as usual but left in f16 (no final Convert to f32) --
+// ov::pass::MarkDequantization (registered in translate_session.cpp) marks the chain so it survives
+// model-build-time ConstantFolding. mul_mat_id.cpp constructs ov::op::internal::GatherMatmul directly
+// on top of the resulting f16 chain.
 ov::Output<ov::Node> make_int8_weights(ov::Tensor & weight,
                                        ov::Tensor & scales,
                                        ov::Tensor & zp,
                                        size_t group_size,
-                                       bool use_bias) {
+                                       bool use_bias,
+                                       bool for_gather_matmul) {
     ov::Shape orig_shape = weight.get_shape();
     bool is_signed = (weight.get_element_type() == ov::element::i8);  // Symmetric: signed weights, no ZP
 
     // Expand dimensions for scales and zp/bias
     auto scale_shape = scales.get_shape();
 
-    ov::Shape packed_shape = {orig_shape[0], orig_shape[1] / group_size, group_size};
+    // Group the innermost (last) dimension. For 2D weights [rows, cols] this yields
+    // [rows, cols/group_size, group_size]; for 3D MoE experts [n_expert, rows, cols] this yields
+    // [n_expert, rows, cols/group_size, group_size].
+    ov::Shape packed_shape = orig_shape;
+    packed_shape.back() /= group_size;
+    packed_shape.push_back(group_size);
+    const size_t group_dim = packed_shape.size() - 2;
 
-    if (packed_shape[1] == 1) {
+    if (packed_shape[group_dim] == 1) {
         // Requantized channel-wise case
-        packed_shape.erase(packed_shape.begin() + 1);
+        packed_shape.erase(packed_shape.begin() + group_dim);
     } else {
         scale_shape.push_back(1);
         scales.set_shape(scale_shape);
@@ -539,7 +552,8 @@ ov::Output<ov::Node> make_int8_weights(ov::Tensor & weight,
                                                                    static_cast<uint8_t *>(weight.data()), nullptr);
         weights_node->get_rt_info()["__gguf_tensor_holder"] = weight;
         auto weights_f16 = std::make_shared<ov::op::v0::Convert>(weights_node, ov::element::f16);
-        result = std::make_shared<ov::op::v1::Multiply>(weights_f16, scales_f16, ov::op::AutoBroadcastType::NUMPY);
+        auto mul = std::make_shared<ov::op::v1::Multiply>(weights_f16, scales_f16, ov::op::AutoBroadcastType::NUMPY);
+        result = mul;
     } else {
         // Unsigned path
         auto weights_node = std::make_shared<ov::op::v0::Constant>(ov::element::u8, packed_shape,
@@ -548,11 +562,25 @@ ov::Output<ov::Node> make_int8_weights(ov::Tensor & weight,
         auto weights_f16 = std::make_shared<ov::op::v0::Convert>(weights_node, ov::element::f16);
 
         if (use_bias && zp.get_size() > 0) {
-            // Bias path: w * s + b (zp tensor holds f16 bias values)
-            auto bias_f16 = std::make_shared<ov::op::v0::Constant>(zp);
-            auto w_s =
-                std::make_shared<ov::op::v1::Multiply>(weights_f16, scales_f16, ov::op::AutoBroadcastType::NUMPY);
-            result = std::make_shared<ov::op::v1::Add>(w_s, bias_f16, ov::op::AutoBroadcastType::NUMPY);
+            // Accurate dequant in the FUSABLE zero-point form: (w - zp) * s, where the zero
+            // point is an exact f16 value zp = -bias/scale (the zp tensor holds bias values
+            // coming in). Algebraically equal to w*s + bias, but unlike an Add(bias) graph this
+            // matches CompressedWeightsBlock's pattern (Constant->Convert->Subtract->Multiply),
+            // so for_gather_matmul weights still fuse into GatherMatmulCompressed. Also avoids
+            // the round(min/scale) error of an integer zero point. Convert bias -> zero-point IN
+            // PLACE in the (possibly buffer-backed) zp tensor to avoid a duplicate allocation.
+            auto * bias_zp_data = zp.data<ov::float16>();
+            const auto * scale_data = scales.data<ov::float16>();
+            const size_t n = zp.get_size();
+            for (size_t i = 0; i < n; i++) {
+                float s = static_cast<float>(scale_data[i]);
+                float b = static_cast<float>(bias_zp_data[i]);
+                bias_zp_data[i] = ov::float16(s != 0.0f ? -b / s : 0.0f);
+            }
+            auto zero_point_f16 = std::make_shared<ov::op::v0::Constant>(zp);
+            auto w_zp =
+                std::make_shared<ov::op::v1::Subtract>(weights_f16, zero_point_f16, ov::op::AutoBroadcastType::NUMPY);
+            result = std::make_shared<ov::op::v1::Multiply>(w_zp, scales_f16, ov::op::AutoBroadcastType::NUMPY);
         } else {
             // Zero point path: (w - zp) * s
             auto zero_point = std::make_shared<ov::op::v0::Constant>(zp);
@@ -563,37 +591,49 @@ ov::Output<ov::Node> make_int8_weights(ov::Tensor & weight,
             auto zero_point_f16 = std::make_shared<ov::op::v0::Convert>(zero_point, ov::element::f16);
             auto w_zp =
                 std::make_shared<ov::op::v1::Subtract>(weights_f16, zero_point_f16, ov::op::AutoBroadcastType::NUMPY);
-            result = std::make_shared<ov::op::v1::Multiply>(w_zp, scales_f16, ov::op::AutoBroadcastType::NUMPY);
+            auto mul = std::make_shared<ov::op::v1::Multiply>(w_zp, scales_f16, ov::op::AutoBroadcastType::NUMPY);
+            result = mul;
         }
     }
 
-    if (packed_shape.size() != 2) {
+    if (packed_shape.size() != orig_shape.size()) {
         // If not requantized channel-wise case, reshape back to original shape
         auto final_shape =
             std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{orig_shape.size()}, orig_shape);
-        result = std::make_shared<ov::op::v1::Reshape>(result, final_shape, false);
+        auto reshaped = std::make_shared<ov::op::v1::Reshape>(result, final_shape, false);
+        result = reshaped;
     }
 
+    if (for_gather_matmul) {
+        return result;
+    }
     return std::make_shared<ov::op::v0::Convert>(result, ov::element::f32);
 }
 
+// See make_int8_weights for the meaning of for_gather_matmul.
 ov::Output<ov::Node> make_int4_weights(ov::Tensor & weight,
                                        ov::Tensor & scales,
                                        ov::Tensor & zp,
                                        size_t group_size,
-                                       bool use_bias) {
+                                       bool use_bias,
+                                       bool for_gather_matmul) {
     ov::Shape orig_weight_shape = weight.get_shape();
     bool is_signed = (weight.get_element_type() == ov::element::i4);  // Symmetric: signed weights, no ZP
 
     // Expand dimensions for scales and zp/bias
     ov::Shape scale_shape = scales.get_shape();
 
-    // Create INT4 weight tensor
-    ov::Shape packed_shape = {orig_weight_shape[0], orig_weight_shape[1] / group_size, group_size};
+    // Create INT4 weight tensor. Group the innermost (last) dimension: for 2D weights
+    // [rows, cols] this yields [rows, cols/group_size, group_size]; for 3D MoE experts
+    // [n_expert, rows, cols] this yields [n_expert, rows, cols/group_size, group_size].
+    ov::Shape packed_shape = orig_weight_shape;
+    packed_shape.back() /= group_size;
+    packed_shape.push_back(group_size);
+    const size_t group_dim = packed_shape.size() - 2;
 
-    if (packed_shape[1] == 1) {
+    if (packed_shape[group_dim] == 1) {
         // Requantized channel-wise case
-        packed_shape.erase(packed_shape.begin() + 1);
+        packed_shape.erase(packed_shape.begin() + group_dim);
     } else {
         scale_shape.push_back(1);
         scales.set_shape(scale_shape);
@@ -613,7 +653,8 @@ ov::Output<ov::Node> make_int4_weights(ov::Tensor & weight,
                                                                    static_cast<uint8_t *>(weight.data()), nullptr);
         weights_node->get_rt_info()["__gguf_tensor_holder"] = weight;
         auto weights_f16 = std::make_shared<ov::op::v0::Convert>(weights_node, ov::element::f16);
-        result = std::make_shared<ov::op::v1::Multiply>(weights_f16, scales_f16, ov::op::AutoBroadcastType::NUMPY);
+        auto mul = std::make_shared<ov::op::v1::Multiply>(weights_f16, scales_f16, ov::op::AutoBroadcastType::NUMPY);
+        result = mul;
     } else {
         // Unsigned path
         auto weights_node = std::make_shared<ov::op::v0::Constant>(ov::element::u4, packed_shape,
@@ -622,11 +663,23 @@ ov::Output<ov::Node> make_int4_weights(ov::Tensor & weight,
         auto weights_f16 = std::make_shared<ov::op::v0::Convert>(weights_node, ov::element::f16);
 
         if (use_bias && zp.get_size() > 0) {
-            // Bias path: w * s + b (zp tensor holds f16 bias values)
-            auto bias_f16 = std::make_shared<ov::op::v0::Constant>(zp);
-            auto w_s =
-                std::make_shared<ov::op::v1::Multiply>(weights_f16, scales_f16, ov::op::AutoBroadcastType::NUMPY);
-            result = std::make_shared<ov::op::v1::Add>(w_s, bias_f16, ov::op::AutoBroadcastType::NUMPY);
+            // Accurate dequant in the FUSABLE zero-point form: (w - zp) * s with an exact f16
+            // zp = -bias/scale. Equivalent to w*s + bias but matches CompressedWeightsBlock's
+            // pattern so for_gather_matmul weights still fuse into GatherMatmulCompressed, and
+            // avoids the round(min/scale) error of an integer zp. Convert bias -> zero-point IN
+            // PLACE in the (possibly buffer-backed) zp tensor to avoid a duplicate allocation.
+            auto * bias_zp_data = zp.data<ov::float16>();
+            const auto * scale_data = scales.data<ov::float16>();
+            const size_t n = zp.get_size();
+            for (size_t i = 0; i < n; i++) {
+                float s = static_cast<float>(scale_data[i]);
+                float b = static_cast<float>(bias_zp_data[i]);
+                bias_zp_data[i] = ov::float16(s != 0.0f ? -b / s : 0.0f);
+            }
+            auto zero_points_f16 = std::make_shared<ov::op::v0::Constant>(zp);
+            auto w_zp =
+                std::make_shared<ov::op::v1::Subtract>(weights_f16, zero_points_f16, ov::op::AutoBroadcastType::NUMPY);
+            result = std::make_shared<ov::op::v1::Multiply>(w_zp, scales_f16, ov::op::AutoBroadcastType::NUMPY);
         } else {
             // Zero point path: (w - zp) * s
             auto zero_points_node = std::make_shared<ov::op::v0::Constant>(zp);
@@ -637,17 +690,22 @@ ov::Output<ov::Node> make_int4_weights(ov::Tensor & weight,
             auto zero_points_f16 = std::make_shared<ov::op::v0::Convert>(zero_points_node, ov::element::f16);
             auto w_zp =
                 std::make_shared<ov::op::v1::Subtract>(weights_f16, zero_points_f16, ov::op::AutoBroadcastType::NUMPY);
-            result = std::make_shared<ov::op::v1::Multiply>(w_zp, scales_f16, ov::op::AutoBroadcastType::NUMPY);
+            auto mul = std::make_shared<ov::op::v1::Multiply>(w_zp, scales_f16, ov::op::AutoBroadcastType::NUMPY);
+            result = mul;
         }
     }
 
-    if (packed_shape.size() != 2) {
+    if (packed_shape.size() != orig_weight_shape.size()) {
         // If not requantized channel-wise case, reshape back to original shape
         auto final_shape = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{orig_weight_shape.size()},
                                                                   orig_weight_shape);
-        result = std::make_shared<ov::op::v1::Reshape>(result, final_shape, false);
+        auto reshaped = std::make_shared<ov::op::v1::Reshape>(result, final_shape, false);
+        result = reshaped;
     }
 
+    if (for_gather_matmul) {
+        return result;
+    }
     return std::make_shared<ov::op::v0::Convert>(result, ov::element::f32);
 }
 
@@ -730,6 +788,13 @@ std::shared_ptr<ov::Node> extract_quantized_weights(const ggml_tensor * tensor,
                                  std::string(ggml_type_name(tensor->type)));
     }
 
+    // 3D MoE expert weights (for_gather_matmul) always use the exact f16 zero-point extraction
+    // (see make_int8_weights/make_int4_weights) rather than the rounded integer zero point --
+    // round(min/scale) error is what corrupts Q4_K/Q5_1 experts, and the f16-zp form still fuses
+    // into GatherMatmulCompressed since it stays a Subtract, not an Add.
+    const bool for_gather_matmul = tensor->ne[2] > 1;
+    use_bias = use_bias || for_gather_matmul;
+
     // Extract quantized data
     switch (tensor->type) {
     case GGML_TYPE_Q4_0:
@@ -757,12 +822,13 @@ std::shared_ptr<ov::Node> extract_quantized_weights(const ggml_tensor * tensor,
         throw std::runtime_error("Unsupported quantized type: " + std::string(ggml_type_name(tensor->type)));
     }
 
-    // Create the OpenVINO weight subgraph
+    // Create the OpenVINO weight subgraph. 3D expert weights (MoE) are routed through the
+    // GatherMatmul-oriented path: dequantized in f16, with constant folding disabled on the chain.
     ov::Output<ov::Node> weight_node;
     if (is_u4) {
-        weight_node = make_int4_weights(weights, scales, zp, weights_per_block, use_bias);
+        weight_node = make_int4_weights(weights, scales, zp, weights_per_block, use_bias, for_gather_matmul);
     } else {
-        weight_node = make_int8_weights(weights, scales, zp, weights_per_block, use_bias);
+        weight_node = make_int8_weights(weights, scales, zp, weights_per_block, use_bias, for_gather_matmul);
     }
 
     auto result = weight_node.get_node_shared_ptr();
@@ -822,8 +888,11 @@ OvWeight process_weight_tensor(const ggml_tensor * tensor, const void * data, vo
 
     OvWeight result;
 
-    // Get 2D shape for weights [rows, cols]
-    ov::Shape node_shape = {static_cast<size_t>(tensor->ne[1]), static_cast<size_t>(tensor->ne[0])};
+    // Get shape for weights: [rows, cols], or [n_expert, rows, cols] for 3D MoE expert weights.
+    ov::Shape node_shape = (tensor->ne[2] > 1) ?
+                               ov::Shape{static_cast<size_t>(tensor->ne[2]), static_cast<size_t>(tensor->ne[1]),
+                                         static_cast<size_t>(tensor->ne[0])} :
+                               ov::Shape{static_cast<size_t>(tensor->ne[1]), static_cast<size_t>(tensor->ne[0])};
 
     // Handle F16/F32/BF16 weights
     if (tensor->type == GGML_TYPE_F32 || tensor->type == GGML_TYPE_F16 || tensor->type == GGML_TYPE_BF16) {
@@ -864,6 +933,14 @@ OvWeight process_weight_tensor(const ggml_tensor * tensor, const void * data, vo
     if (layout.total_size == 0) {
         OPENVINO_THROW("Unsupported quantized type: ", ggml_type_name(tensor->type));
     }
+
+    // 3D MoE expert weights (for_gather_matmul) always use the exact f16 zero-point path (see
+    // extract_quantized_weights) -- must be kept in sync with the "use_bias || for_gather_matmul"
+    // check in ggml_openvino_get_extracted_layout, which sizes/offsets the zp slot accordingly.
+    // Requantized tensors (layout.is_requant) are handled by requantize_to_buffers instead, whose
+    // zp sizing/type is unaffected by for_gather_matmul, so they are excluded here.
+    const bool for_gather_matmul = tensor->ne[2] > 1;
+    const bool zp_is_f16 = !layout.is_requant && (use_bias || for_gather_matmul);
 
     const bool is_3d_mxfp4_moe = tensor->type == GGML_TYPE_MXFP4 && (tensor->ne[2] > 1 || tensor->ne[3] > 1);
     if (is_3d_mxfp4_moe) {
@@ -914,7 +991,8 @@ OvWeight process_weight_tensor(const ggml_tensor * tensor, const void * data, vo
                                         ov::element::f4e2m1 :
                                         (layout.is_symmetric ? (layout.is_u4 ? ov::element::i4 : ov::element::i8) :
                                                                (layout.is_u4 ? ov::element::u4 : ov::element::u8));
-    ov::Shape scale_shape = {node_shape[0], node_shape[1] / layout.weights_per_block};
+    ov::Shape scale_shape = node_shape;
+    scale_shape.back() /= layout.weights_per_block;
 
     if (tensor->type == GGML_TYPE_MXFP4) {
         if (tensor->ne[2] == 1 && tensor->ne[3] == 1) {
@@ -936,7 +1014,8 @@ OvWeight process_weight_tensor(const ggml_tensor * tensor, const void * data, vo
         const ov::element::Type scale_type = tensor->type == GGML_TYPE_MXFP4 ? ov::element::f8e8m0 : ov::element::f16;
         result.scales = ov::Tensor(scale_type, scale_shape, buf_base + layout.scales_offset);
         if (!layout.is_symmetric) {
-            ov::element::Type zp_type = layout.is_u4 ? ov::element::u4 : ov::element::u8;
+            ov::element::Type zp_type =
+                zp_is_f16 ? ov::element::f16 : (layout.is_u4 ? ov::element::u4 : ov::element::u8);
             result.zp = ov::Tensor(zp_type, scale_shape, buf_base + layout.zp_offset);
         }
         // else: result.zp remains default-constructed (empty) for symmetric
@@ -945,7 +1024,7 @@ OvWeight process_weight_tensor(const ggml_tensor * tensor, const void * data, vo
         const ov::element::Type scale_type = tensor->type == GGML_TYPE_MXFP4 ? ov::element::f8e8m0 : ov::element::f16;
         result.scales = ov::Tensor(scale_type, scale_shape);
         if (!layout.is_symmetric) {
-            if (use_bias) {
+            if (zp_is_f16) {
                 result.zp = ov::Tensor(ov::element::f16, scale_shape);
             } else {
                 ov::element::Type zp_type = layout.is_u4 ? ov::element::u4 : ov::element::u8;

--- a/ggml/src/ggml-openvino/ggml-quants.h
+++ b/ggml/src/ggml-openvino/ggml-quants.h
@@ -54,17 +54,30 @@ void extract_mxfp4_data(const ggml_tensor * tensor, ov::Tensor & weights_arr, ov
 
 static constexpr size_t GGML_QUANTIZATION_GROUP_SIZE = 32;
 
+// If for_gather_matmul is true, the weight tensor may be N-D (e.g. 3D MoE expert weights
+// [n_expert, rows, cols]). The dequantization chain (Convert->[Subtract]->Multiply) is built as
+// usual but left in f16 (no final Convert to f32) -- ov::pass::MarkDequantization (registered in
+// translate_session.cpp) marks the chain so it survives model-build-time ConstantFolding -- see
+// make_int8_weights.cpp/make_int4_weights.cpp. mul_mat_id.cpp constructs ov::op::internal::GatherMatmul
+// directly from the resulting f16 dequant chain.
+//
+// When use_bias is true (explicitly, or implicitly because for_gather_matmul is true), the zp
+// tensor is expected to hold an exact f16 bias value (rather than a rounded integer zero point);
+// it is converted in place into an exact zero_point = -bias/scale and consumed via Subtract, not
+// Add, so the chain still matches OpenVINO's Convert->Subtract->Multiply decompression pattern.
 ov::Output<ov::Node> make_int8_weights(ov::Tensor & weight,
                                        ov::Tensor & scales,
                                        ov::Tensor & zp,
                                        size_t group_size = GGML_QUANTIZATION_GROUP_SIZE,
-                                       bool use_bias = false);
+                                       bool use_bias = false,
+                                       bool for_gather_matmul = false);
 
 ov::Output<ov::Node> make_int4_weights(ov::Tensor & weight,
                                        ov::Tensor & scales,
                                        ov::Tensor & zp,
                                        size_t group_size = GGML_QUANTIZATION_GROUP_SIZE,
-                                       bool use_bias = false);
+                                       bool use_bias = false,
+                                       bool for_gather_matmul = false);
 
 ov::Output<ov::Node> make_mxfp4_weights(ov::Tensor & weight, ov::Tensor & scales);
 
@@ -80,7 +93,9 @@ std::shared_ptr<ov::Node> extract_quantized_weights(
     ov::Tensor & weights,
     ov::Tensor & scales,
     ov::Tensor & zp,
-    bool use_bias = false);  // Use fp bias instead of quantized zero_point (for test-backend-ops)
+    bool use_bias = false);  // Use an exact f16 zero point (vs. a rounded integer one); always
+                             // used for for_gather_matmul (3D MoE expert) weights regardless of
+                             // this flag, and also settable explicitly for test-backend-ops.
 
 // Requantize weights from tensor to target format, writing to provided buffers
 // For F16 target, only weights buffer is used (scales/zp ignored)
@@ -133,7 +148,10 @@ OvWeight process_weight_tensor(
     const ggml_tensor * tensor,
     const void * data,                 // Source data pointer (may differ from tensor->data)
     void * output_base_ptr = nullptr,  // Base pointer for output buffers (or nullptr for internal allocation)
-    bool use_bias = false);            // Use fp bias instead of quantized zero_point, only used in test-backend-ops
+    bool use_bias = false);            // Use an exact f16 zero point (vs. a rounded integer one);
+                                       // always used for for_gather_matmul (3D MoE expert) weights
+                                       // regardless of this flag, and also settable explicitly for
+                                       // test-backend-ops.
 
 void quantize_q4_0(const float * x,
                    ov::Tensor & weights_arr,

--- a/ggml/src/ggml-openvino/openvino/op/gather_matmul.hpp
+++ b/ggml/src/ggml-openvino/openvino/op/gather_matmul.hpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Local mirror of OpenVINO's internal ov::op::internal::GatherMatmul op.
+//
+// The op class body (validate_and_infer_types / clone_with_new_inputs) is
+// provided by the linked libopenvino.so; only the declaration is needed here so
+// the backend can construct the node directly (same approach as GatedDeltaNet).
+// The class layout must stay in sync with
+//   openvino/src/common/transformations/include/ov_ops/gather_matmul.hpp
+//
+// \note GatherMatmul op class is under development and subject to change.
+
+#pragma once
+
+#include "openvino/op/op.hpp"
+
+namespace ov::op::internal {
+
+class OPENVINO_API GatherMatmul : public ov::op::Op {
+public:
+    OPENVINO_OP("GatherMatmul")
+
+    GatherMatmul() = default;
+
+    GatherMatmul(const ov::Output<Node>& A,
+                 const ov::Output<Node>& B,
+                 const ov::Output<Node>& indices,
+                 const ov::Output<Node>& bias);
+
+    GatherMatmul(const ov::Output<Node>& A, const ov::Output<Node>& B, const ov::Output<Node>& indices);
+
+    std::shared_ptr<Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
+
+    void validate_and_infer_types() override;
+
+private:
+    // the weights matrix B is expected to have the transposed form [group, N, K]
+    static constexpr bool transp_a = false;
+    static constexpr bool transp_b = true;
+};
+
+}  // namespace ov::op::internal

--- a/ggml/src/ggml-openvino/openvino/op/get_rows.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/get_rows.cpp
@@ -5,9 +5,12 @@
 #include <climits>
 #include <openvino/core/node.hpp>
 #include <openvino/core/node_output.hpp>
+#include <openvino/op/broadcast.hpp>
+#include <openvino/op/concat.hpp>
 #include <openvino/op/constant.hpp>
 #include <openvino/op/convert.hpp>
 #include <openvino/op/gather.hpp>
+#include <openvino/op/shape_of.hpp>
 #include <openvino/op/slice.hpp>
 #include <openvino/op/squeeze.hpp>
 #include <openvino/op/unsqueeze.hpp>
@@ -59,7 +62,62 @@ OutputVector translate_get_rows(const NodeContext & context) {
             auto axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {1});
             data =
                 std::make_shared<ov::op::v0::Squeeze>(data, ov::op::v0::Constant::create(ov::element::i64, {1}, {0}));
-            res = std::make_shared<ov::op::v8::Gather>(data, indices, axis, 1);
+            // data: [batch, rows, ...], indices: [batch, n] - this is a batched gather
+            // (batch_dims=1) along the rows axis. The data and indices batch dims are
+            // logically equal (both == n_tokens) but reach this node through independent
+            // reshapes, so the GPU plugin's gather shape inference cannot prove
+            // data.shape[0] == indices.shape[0] and rejects the node. We must tie both
+            // batch dims to the SAME value, and crucially that value must stay DYNAMIC.
+            const auto data_ps = data.get_partial_shape();
+            const auto idx_ps = indices.get_partial_shape();
+            const bool data_batch_static = data_ps.rank().is_static() && data_ps[0].is_static();
+            const bool idx_batch_dynamic = idx_ps.rank().is_dynamic() || idx_ps[0].is_dynamic();
+
+            if (data_batch_static && idx_batch_dynamic) {
+                // MoE per-expert-scale path: `data` is a statically-tiled REPEAT
+                // (ggml_repeat_4d(scale, 1, n_expert, n_tokens, 1)) whose batch dim is a
+                // compile-time-constant n_tokens, and every batch slice is IDENTICAL (it was
+                // tiled from a single [1, n_expert, 1] scale). `indices` (selected_experts)
+                // carries the genuinely dynamic token dim. Broadcasting indices up to the
+                // static data batch (the naive fix) would freeze the token dim to the
+                // captured prefill length, and that static value then flows through the
+                // gather into the residual stream, making every following decoder layer
+                // static -> triggers the GPU in-place-concat KV-cache corruption (only
+                // layer 0 stays dynamic). A static->dynamic Broadcast cannot expand, so
+                // instead collapse the redundant data batch to 1 and broadcast 1->dynamic to
+                // match the indices batch. Mathematically identical (the slices are equal),
+                // and the whole graph stays dynamic.
+                auto zero = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
+                auto one = ov::op::v0::Constant::create(ov::element::i64, {1}, {1});
+                auto axis0 = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
+                auto data_b1 = std::make_shared<ov::op::v8::Slice>(data, zero, one, one, axis0);  // [1, rows, ...]
+
+                auto idx_shape = std::make_shared<ov::op::v3::ShapeOf>(indices, ov::element::i64);
+                auto idx_batch = get_dimensions(idx_shape, {0});  // [batch] (dynamic)
+                auto data_b1_shape = std::make_shared<ov::op::v3::ShapeOf>(data_b1, ov::element::i64);
+                const auto rank = data_ps.rank().get_length();
+                std::vector<int> rest_axes;
+                for (int a = 1; a < rank; ++a) {
+                    rest_axes.push_back(a);
+                }
+                auto data_rest = get_dimensions(data_b1_shape, rest_axes);  // [rows, ...]
+                auto data_target = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{idx_batch, data_rest}, 0);
+                data =
+                    std::make_shared<ov::op::v3::Broadcast>(data_b1, data_target, ov::op::BroadcastType::BIDIRECTIONAL);
+                res = std::make_shared<ov::op::v8::Gather>(data, indices, axis, 1);
+            } else {
+                // General case: tie the indices batch to the data batch (the data batch is
+                // already dynamic, e.g. the routing-weights gather whose data comes from the
+                // activations). Broadcast indices to [data_batch, indices_n].
+                auto data_shape = std::make_shared<ov::op::v3::ShapeOf>(data, ov::element::i64);
+                auto data_batch = get_dimensions(data_shape, {0});  // [batch]
+                auto idx_shape = std::make_shared<ov::op::v3::ShapeOf>(indices, ov::element::i64);
+                auto idx_n = get_dimensions(idx_shape, {1});  // [n]
+                auto idx_target = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{data_batch, idx_n}, 0);
+                indices = std::make_shared<ov::op::v3::Broadcast>(indices, idx_target,
+                                                                  ov::op::BroadcastType::BIDIRECTIONAL);
+                res = std::make_shared<ov::op::v8::Gather>(data, indices, axis, 1);
+            }
         }
     } else if (context.is_stateful() && data.get_partial_shape().rank() == 3) {
         auto axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {1});

--- a/ggml/src/ggml-openvino/openvino/op/mul_mat_id.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/mul_mat_id.cpp
@@ -1,6 +1,7 @@
 #include "../node_context.h"
 #include "../op_table.h"
 #include "../utils.h"
+#include "gather_matmul.hpp"
 
 #include <cstdint>
 #include <cstring>
@@ -18,6 +19,7 @@
 #include <openvino/op/reshape.hpp>
 #include <openvino/op/shape_of.hpp>
 #include <openvino/op/slice.hpp>
+#include <openvino/op/transpose.hpp>
 #include <openvino/op/unsqueeze.hpp>
 #include <vector>
 
@@ -144,22 +146,36 @@ OutputVector translate_mul_mat_id(const NodeContext & context) {
                                           context.get_name());
     }
 
+    // General (non-packed) path: dense F32/F16/BF16 weights, or the f16 dequantization chain for
+    // quantized MoE experts (see extract_quantized_weights / make_int4_weights / make_int8_weights in
+    // ggml-quants.cpp). Routed through ov::op::internal::GatherMatmul instead of a naive
+    // Gather+Broadcast+MatMul, so the selected expert's full weight matrix is never materialized per
+    // token. The CPU plugin's ConvertGatherMatmulToGatherMatmulCompressed pass (run during
+    // compile_model) fuses the dequantization chain feeding GatherMatmul's B input into a
+    // GatherMatmulCompressed node automatically, as long as MarkDequantization has marked the chain --
+    // see translate_session.cpp's apply_transformations for the MarkDequantization registration.
+    //
     // OpenVINO sees GGML tensors in reversed dimension order:
-    //   weights: [1, n_expert, m, k]
     //   activations: [1, n_tokens, n_used_or_1, k]
     //   ids: [1, 1, n_tokens, n_used]
-    // Rebuild the logical ranks explicitly from the 4D inputs instead of relying
-    // on fixed squeeze axes: real graphs can arrive through VIEW/RESHAPE chains
-    // where singleton axes are still represented differently at this point.
-    auto expert_weights_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(expert_weights, ov::element::i64);
+    // expert_weights is either [1, n_expert, m, k] (4D, e.g. non-quantized weights without a
+    // pre-built extra) or already [n_expert, m, k] (3D, weights routed through
+    // process_weight_tensor) -- GatherMatmul's B input expects the latter.
+    auto expert_weights_rank = expert_weights.get_partial_shape().rank();
+    FRONT_END_OP_CONVERSION_CHECK(expert_weights_rank.is_static(),
+                                  "Expected static rank for MUL_MAT_ID expert weights");
+    if (expert_weights_rank.get_length() == 4) {
+        auto expert_weights_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(expert_weights, ov::element::i64);
+        auto expert_weights_shape_3d = get_dimensions(expert_weights_shape_4d, {1, 2, 3});
+        expert_weights = std::make_shared<ov::op::v1::Reshape>(expert_weights, expert_weights_shape_3d, false);
+    }
+
     auto activations_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(activations, ov::element::i64);
     auto ids_shape_4d = std::make_shared<ov::op::v3::ShapeOf>(ids, ov::element::i64);
 
-    auto expert_weights_shape_3d = get_dimensions(expert_weights_shape_4d, {1, 2, 3});
     auto activations_shape_3d = get_dimensions(activations_shape_4d, {1, 2, 3});
     auto ids_shape_2d = get_dimensions(ids_shape_4d, {2, 3});
 
-    expert_weights = std::make_shared<ov::op::v1::Reshape>(expert_weights, expert_weights_shape_3d, false);
     activations = std::make_shared<ov::op::v1::Reshape>(activations, activations_shape_3d, false);
     ids = std::make_shared<ov::op::v1::Reshape>(ids, ids_shape_2d, false);
 
@@ -167,51 +183,24 @@ OutputVector translate_mul_mat_id(const NodeContext & context) {
         ids = std::make_shared<ov::op::v0::Convert>(ids, ov::element::i32);
     }
 
-    auto gather_axis = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0});
-    ov::Output<ov::Node> selected_weights = std::make_shared<ov::op::v8::Gather>(expert_weights, ids, gather_axis);
-
     const auto output_type = context.get_output_type();
-    if (selected_weights.get_element_type() != ov::element::f32) {
-        selected_weights = std::make_shared<ov::op::v0::Convert>(selected_weights, ov::element::f32);
-    }
     if (activations.get_element_type() != ov::element::f32) {
         activations = std::make_shared<ov::op::v0::Convert>(activations, ov::element::f32);
     }
 
-    auto activations_shape = std::make_shared<ov::op::v3::ShapeOf>(activations, ov::element::i64);
-    auto ids_shape = std::make_shared<ov::op::v3::ShapeOf>(ids, ov::element::i64);
-    ov::Output<ov::Node> acts_target_dims = std::make_shared<ov::op::v0::Concat>(
-        ov::OutputVector{
-            get_dimensions(activations_shape, {0}),
-            get_dimensions(ids_shape, {1}),
-            get_dimensions(activations_shape, {2}),
-        },
-        0);
-    ov::Output<ov::Node> acts_broadcasted =
-        std::make_shared<ov::op::v3::Broadcast>(activations, acts_target_dims, ov::op::BroadcastType::BIDIRECTIONAL);
+    // GatherMatmul's A input is [n_used_or_1, n_tokens, k]; activations_3d is
+    // [n_tokens, n_used_or_1, k].
+    auto activations_transpose_order = const_i64({1, 0, 2});
+    ov::Output<ov::Node> activations_for_gather =
+        std::make_shared<ov::op::v1::Transpose>(activations, activations_transpose_order);
 
-    auto unsqueeze_axes = ov::op::v0::Constant::create(ov::element::i64, {1}, {2});
-    auto activations_expanded = std::make_shared<ov::op::v0::Unsqueeze>(acts_broadcasted, unsqueeze_axes);
+    ov::Output<ov::Node> result = std::make_shared<ov::op::internal::GatherMatmul>(activations_for_gather, expert_weights, ids);
 
-    auto batch_dim = ov::op::v0::Constant::create(ov::element::i64, {1}, {1});
-    auto output_shape = context.get_output_shape();
-    FRONT_END_OP_CONVERSION_CHECK(output_shape.rank().is_static() && output_shape.rank().get_length() == 4,
-                                  "Unexpected MUL_MAT_ID output rank");
-    FRONT_END_OP_CONVERSION_CHECK(output_shape[3].is_static(), "Expected static row dimension for MUL_MAT_ID output");
-    const auto row_dim_value = output_shape[3].get_length();
-    auto row_dim = ov::op::v0::Constant::create(ov::element::i64, {1}, {row_dim_value});
-
-    ov::Output<ov::Node> result =
-        std::make_shared<ov::op::v0::MatMul>(activations_expanded, selected_weights, false, true);
-
-    auto result_target_dims = std::make_shared<ov::op::v0::Concat>(
-        ov::OutputVector{
-            batch_dim,
-            get_dimensions(ids_shape, {0, 1}),
-            row_dim,
-        },
-        0);
-    result = std::make_shared<ov::op::v1::Reshape>(result, result_target_dims, false);
+    // result is [n_used, n_tokens, m]; GGML expects [1, n_tokens, n_used, m].
+    auto result_transpose_order = const_i64({1, 0, 2});
+    result = std::make_shared<ov::op::v1::Transpose>(result, result_transpose_order);
+    auto unsqueeze_axes = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
+    result = std::make_shared<ov::op::v0::Unsqueeze>(result, unsqueeze_axes);
 
     if (result.get_element_type() != output_type) {
         result = std::make_shared<ov::op::v0::Convert>(result, output_type);

--- a/ggml/src/ggml-openvino/openvino/op/view.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/view.cpp
@@ -1,8 +1,11 @@
 #include "../op_table.h"
 #include "../utils.h"
 
+#include <openvino/op/concat.hpp>
 #include <openvino/op/constant.hpp>
+#include <openvino/op/gather.hpp>
 #include <openvino/op/reshape.hpp>
+#include <openvino/op/shape_of.hpp>
 #include <openvino/op/slice.hpp>
 #include <set>
 
@@ -15,6 +18,123 @@ OutputVector translate_view(const NodeContext & context) {
     num_inputs_check(context, 1, 1);
 
     if (!context.is_static()) {
+        // On the stateless/non-static path VIEW is normally a no-op (consumers re-slice).
+        // EXCEPTION: the MoE expert aggregation slices each expert plane out of
+        // ffn_moe_weighted [n_embd, n_expert_used, n_tokens] with ggml_view_2d and then
+        // sums the planes with a chain of ADDs (llama-graph.cpp). Those ADDs read this
+        // VIEW node directly from the tensor map and do NOT re-slice, so a no-op here
+        // makes every plane the full tensor and the expert sum collapses. Materialize the
+        // single-expert slice here. Gated by name (ffn_moe_weighted...view) so it can't
+        // affect any other view.
+        const std::string & vname = context.get_name();
+        if (vname.find("ffn_moe_weighted") != std::string::npos) {
+            auto src_ps = context.get_input_shape(0);
+            auto dst_ps = context.get_output_shape();
+            if (src_ps.rank().is_static() && dst_ps.rank().is_static() && src_ps.rank() == dst_ps.rank() &&
+                src_ps.is_static() && dst_ps.is_static()) {
+                auto sst = context.get_input_stride(0);
+                auto dst = context.get_output_stride();
+                size_t voff = context.get_output_op_offset();
+                auto ss = src_ps.to_shape();
+                auto dd = dst_ps.to_shape();
+                const size_t nd = ss.size();
+                if (sst.size() == nd && dst.size() == nd) {
+                    // Map each dst axis of size>1 to a src axis with equal (size,stride);
+                    // the unmatched src axis of size>1 is the indexed expert axis.
+                    // dst_to_src[d] records which src axis each dst axis came from, so we can
+                    // later pull the dynamic (token) dim from the right source axis at runtime.
+                    std::vector<bool> used(nd, false);
+                    std::vector<int> dst_to_src(nd, -1);
+                    bool ok = true;
+                    for (size_t d = 0; d < nd; ++d) {
+                        if (dd[d] == 1) {
+                            continue;
+                        }
+                        int found = -1;
+                        for (size_t s = 0; s < nd; ++s) {
+                            if (!used[s] && ss[s] == dd[d] && sst[s] == dst[d]) {
+                                found = (int) s;
+                                break;
+                            }
+                        }
+                        if (found < 0) {
+                            ok = false;
+                            break;
+                        }
+                        used[found] = true;
+                        dst_to_src[d] = found;
+                    }
+                    int dropped = -1;
+                    if (ok) {
+                        for (size_t s = 0; s < nd; ++s) {
+                            if (!used[s] && ss[s] > 1) {
+                                if (dropped >= 0) {
+                                    ok = false;
+                                    break;
+                                }
+                                dropped = (int) s;
+                            }
+                        }
+                    }
+                    if (ok && dropped >= 0) {
+                        const size_t dstr = sst[dropped];
+                        const int64_t dsz = (int64_t) ss[dropped];
+                        if (dstr > 0 && voff % dstr == 0) {
+                            const int64_t sel = (int64_t) (voff / dstr);
+                            if (sel >= 0 && sel < dsz) {
+                                ov::Output<ov::Node> sl = std::make_shared<ov::op::v8::Slice>(
+                                    context.get_input(0),
+                                    ov::op::v0::Constant::create(ov::element::i64, {1}, {sel}),
+                                    ov::op::v0::Constant::create(ov::element::i64, {1}, {sel + 1}),
+                                    ov::op::v0::Constant::create(ov::element::i64, {1}, {1}),
+                                    ov::op::v0::Constant::create(ov::element::i64, {1}, {dropped}));
+                                // Build the reshape target from the (concrete) dst shape, but
+                                // keep the dynamic token axis dynamic instead of freezing it
+                                // to the captured n_tokens. Without this the constant dst
+                                // shape bakes in the prefill token count and the static value
+                                // flows downstream, turning every later decoder layer static
+                                // (the GPU in-place-concat KV-cache bug). The token axis is
+                                // PERMUTED between the sliced input and the dst (e.g. input
+                                // [1,tok,expert,emb] -> dst [1,1,tok,emb]), so special_zero
+                                // (which copies the same-position dim) is not enough: pull the
+                                // dynamic dim from the correct SOURCE axis via ShapeOf+Gather
+                                // and place it at the dst token position.
+                                const int32_t dyn = context.get_op_dynamic_dim();  // output ggml axis, -1 if none
+                                int dst_ov_axis = (dyn != -1) ? (3 - (int) dyn) : -1;  // get_shape() reverses ggml order
+                                int src_ov_axis = (dst_ov_axis >= 0 && dst_ov_axis < (int) nd)
+                                                      ? dst_to_src[dst_ov_axis]
+                                                      : -1;
+                                if (dst_ov_axis >= 0 && src_ov_axis >= 0) {
+                                    // target = concat of per-axis scalars; the token axis is a
+                                    // runtime Gather of the slice's shape, the rest are constants.
+                                    auto sl_shape = std::make_shared<ov::op::v3::ShapeOf>(sl, ov::element::i64);
+                                    auto tok_dim = std::make_shared<ov::op::v8::Gather>(
+                                        sl_shape,
+                                        ov::op::v0::Constant::create(ov::element::i64, {1}, {src_ov_axis}),
+                                        ov::op::v0::Constant::create(ov::element::i64, {}, {0}));
+                                    ov::OutputVector parts;
+                                    for (int a = 0; a < (int) nd; ++a) {
+                                        if (a == dst_ov_axis) {
+                                            parts.push_back(tok_dim);
+                                        } else {
+                                            parts.push_back(ov::op::v0::Constant::create(
+                                                ov::element::i64, {1}, {(int64_t) dd[a]}));
+                                        }
+                                    }
+                                    auto dc = std::make_shared<ov::op::v0::Concat>(parts, 0);
+                                    auto rs = std::make_shared<ov::op::v1::Reshape>(sl, dc, false);
+                                    return rename_outputs_with_suffix({rs}, context.get_name());
+                                }
+                                auto dc = ov::op::v0::Constant::create(
+                                    ov::element::i64, {nd}, std::vector<int64_t>(dd.begin(), dd.end()));
+                                auto rs = std::make_shared<ov::op::v1::Reshape>(sl, dc, false);
+                                return rename_outputs_with_suffix({rs}, context.get_name());
+                            }
+                        }
+                    }
+                }
+            }
+        }
         return {context.get_input(0)};
     }
 

--- a/ggml/src/ggml-openvino/openvino/pass/mark_dequantization_subgraph.h
+++ b/ggml/src/ggml-openvino/openvino/pass/mark_dequantization_subgraph.h
@@ -1,0 +1,44 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Local mirror of OpenVINO's ov::pass::MarkDequantization pass declaration.
+//
+// The pass body is provided by the linked libopenvino.so; only the declaration is needed here so
+// we can register it directly in our own TranslateSession::apply_transformations (same approach as
+// MarkCompressedFloatConstants's local mirror in mark_decompression_convert_constant_folding.h). This
+// lets us mark our GatherMatmul dequantization chain with disable_constant_folding regardless of the
+// CPU/GPU plugin's own is_decompression_multiply() consumer allowlist.
+// The class layout must stay in sync with
+//   openvino/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
+
+#pragma once
+
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/core/visibility.hpp"
+#include "openvino/pass/matcher_pass.hpp"
+
+#ifdef OPENVINO_STATIC_LIBRARY
+#    define TRANSFORMATIONS_API
+#else
+#    ifdef IMPLEMENT_OPENVINO_API
+#        define TRANSFORMATIONS_API OPENVINO_CORE_EXPORTS
+#    else
+#        define TRANSFORMATIONS_API OPENVINO_CORE_IMPORTS
+#    endif  // IMPLEMENT_OPENVINO_API
+#endif      // OPENVINO_STATIC_LIBRARY
+
+namespace ov {
+namespace pass {
+
+class TRANSFORMATIONS_API MarkDequantization;
+
+}  // namespace pass
+}  // namespace ov
+
+class ov::pass::MarkDequantization : public MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("MarkDequantization")
+    explicit MarkDequantization(const element::TypeVector & precisions,
+                                bool fold_subtract_const = false,
+                                bool fold_multiply_const = true);
+};

--- a/ggml/src/ggml-openvino/openvino/translate_session.cpp
+++ b/ggml/src/ggml-openvino/openvino/translate_session.cpp
@@ -4,6 +4,7 @@
 #include "ggml-openvino/openvino/utils.h"
 #include "input_model.h"
 #include "pass/mark_decompression_convert_constant_folding.h"
+#include "pass/mark_dequantization_subgraph.h"
 #include "pass/squeeze_matmul.h"
 #include "rt_info/weightless_caching_attributes.hpp"
 
@@ -13,6 +14,7 @@
 #include <memory>
 #include <openvino/core/node.hpp>
 #include <openvino/core/preprocess/pre_post_process.hpp>
+#include <openvino/core/shape.hpp>
 #include <openvino/core/type/element_type.hpp>
 #include <openvino/op/add.hpp>
 #include <openvino/op/broadcast.hpp>
@@ -320,10 +322,13 @@ std::shared_ptr<Model> TranslateSession::translate_graph(const frontend::InputMo
     //
     // Small constants (< 16 elements) are excluded since they may be introduced by
     // optimization patterns and the overhead is negligible.
+    //
+    // Note: use shape_size() rather than byte_size()/element_type().size() - GatherMatmul's default
+    // bias is a Constant(element::dynamic, Shape{0}), whose element_type().size() is 0 and would
+    // divide by zero.
     size_t offset = 0;
     for (auto & node : resulting_model->get_ordered_ops()) {
-        if (auto cnst = ov::as_type_ptr<ov::op::v0::Constant>(node);
-            cnst && cnst->get_byte_size() / cnst->get_element_type().size() >= 16) {
+        if (auto cnst = ov::as_type_ptr<ov::op::v0::Constant>(node); cnst && ov::shape_size(cnst->get_shape()) >= 16) {
             auto & rt_info = cnst->get_rt_info();
             if (rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static()) == rt_info.end()) {
                 rt_info[ov::WeightlessCacheAttribute::get_type_info_static()] =
@@ -340,6 +345,12 @@ std::shared_ptr<Model> TranslateSession::apply_transformations(std::shared_ptr<M
         ov::pass::Manager manager;
         manager.set_per_pass_validation(true);
         manager.register_pass<ov::pass::MarkCompressedFloatConstants>();
+        // Marks the Convert/Subtract/Multiply nodes of our GatherMatmul dequantization chain
+        // (make_int4_weights/make_int8_weights, for_gather_matmul=true) with disable_constant_folding,
+        // so it survives ConstantFolding regardless of whether the target plugin's own
+        // is_decompression_multiply() recognizes GatherMatmul as a valid consumer.
+        manager.register_pass<ov::pass::MarkDequantization>(
+            std::vector<ov::element::Type>{ov::element::u8, ov::element::i8, ov::element::u4, ov::element::i4});
 
         if (ggml_model_decoder->is_stateful()) {
             const auto kv_param_res_names = ggml_model_decoder->get_kv_param_res_names();

--- a/ggml/src/ggml-openvino/openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/openvino/utils.cpp
@@ -292,17 +292,40 @@ ov::Output<ov::Node> process_view_input_new(const NodeContext & context, int inp
 
     // If translate_view already resolved this VIEW (produced a Slice), the input
     // will already have the expected shape — skip re-slicing.
+    //
+    // Two notions of "matches" are accepted per axis:
+    //   - both dims static and equal, OR
+    //   - both dims dynamic.
+    // The dynamic case matters for the MoE expert-plane views: translate_view now emits a
+    // DYNAMIC-token slice (so the token dim is not frozen). An all-static-only check would
+    // see the dynamic token dim, decide the shapes "don't match", and fall through to
+    // re-slice/flatten the already-resolved view (a Reshape to the full flattened
+    // n_expert_used*n_embd tail, which then conflicts with the single-plane input). Treat a
+    // dynamic-vs-dynamic axis as matching so the already-resolved view is reused as-is.
+    //
+    // A third case matters for split-model MoE fragments: translate_view resolves the
+    // expert-plane view against the fragment's INPUT parameter. When the graph is split
+    // the token axis of that parameter may already be concrete (static n_tokens) even
+    // though get_view_input_ov_shape() still reports it as dynamic (-1). The resolved
+    // view is then static [1,1,n_tokens,n_embd] while `expected` is [1,1,?,n_embd].
+    // An "expected dynamic, actual static" axis is a valid concretization of the SAME
+    // resolved view, so treat it as matching too. Falling through to process_single_view
+    // here would re-slice/re-flatten the already-resolved single-plane view against the
+    // recorded (multi-plane) source strides and emit a constant-target Reshape whose baked
+    // dims no longer divide the concretized input -> "dimensions do not evenly divide".
     auto expected_ov_shape = context.get_view_input_ov_shape(input_index, 0);
     auto actual_shape = input.get_partial_shape();
     if (expected_ov_shape.rank().is_static() && actual_shape.rank().is_static() &&
         expected_ov_shape.rank() == actual_shape.rank()) {
         bool shapes_match = true;
         for (int64_t i = 0; i < expected_ov_shape.rank().get_length(); ++i) {
-            if (!expected_ov_shape[i].is_static() || !actual_shape[i].is_static()) {
-                shapes_match = false;
-                break;
-            }
-            if (expected_ov_shape[i] != actual_shape[i]) {
+            const bool both_dynamic = expected_ov_shape[i].is_dynamic() && actual_shape[i].is_dynamic();
+            const bool both_static_equal = expected_ov_shape[i].is_static() && actual_shape[i].is_static() &&
+                                           expected_ov_shape[i] == actual_shape[i];
+            // expected dynamic, actual static: the resolved view already carries the
+            // concrete size for this fragment; reuse it rather than re-materializing.
+            const bool expected_dyn_actual_static = expected_ov_shape[i].is_dynamic() && actual_shape[i].is_static();
+            if (!both_dynamic && !both_static_equal && !expected_dyn_actual_static) {
                 shapes_match = false;
                 break;
             }


### PR DESCRIPTION
@cavusmustafa  Changes from your PR https://github.com/ravi9/llama.cpp/pull/221 included here

1. when use_bias=true, use `(w - zp_f16) * scale` instead of `w * scale + bias_f16)`. For quantized expert weights, use_bias is always true
2. changes in other ops (eg process_view)

Differences from your PR:

1. use rank-3 shape for expert weights after dequantaztion subgraph (ie rank-4 before dequant) instead of rank-2. So that both CPU and GPU recognize the dequantization pattern by default and can fuse to GatherMatmulGather
2. copied GatherMatmul header file and construct it directly, like what did with GatedDeltaNet
3. for CPU, this PR https://github.com/openvinotoolkit/openvino/pull/36937 is needed
4. for CPU and GPU https://github.com/openvinotoolkit/openvino/pull/36936 is needed

Both PRs in ov are needed. Without the first one, the dequantization subgraph will be converted to a snippet in ov cpu, preventing GatherMatmulCompressed fusion. Without the second one, ov::pass::KeepConstPrecision will not be called and u4->u8 conversion will happen on both CPU and GPU. Once the the second PR is merged, we can also remove the copied mark_dequantzation_subgraph.hpp