### PR TITLE
Optimize MoE expert aggregation with ReduceSums

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -125,6 +125,53 @@ bool is_conv_state_writeback(const ggml_tensor * node) {
            node->src[0]->src[0]->op == GGML_OP_CONCAT && node->src[1] != nullptr && node->src[1]->op == GGML_OP_VIEW &&
            node->src[1]->view_src == node->view_src;
 }
+
+// MoE expert aggregation (build_moe_ffn in llama-graph.cpp): each expert plane is
+// `ggml_view_2d(experts, n_embd, n_tokens, experts->nb[2], i*experts->nb[1])` and the planes
+// are summed with a chain of ADDs: moe_out = ((view_0 + view_1) + view_2) + ... + view_{n-1}.
+// Detected structurally by walking the ADD chain and checking every leaf is a same-shape,
+// same-stride VIEW of one common base tensor, indexed by a distinct expert-plane offset, and
+// that the chain covers every plane of that base (leaf count == base->ne[1]). Only the
+// outermost ADD of the chain satisfies this (inner ADDs see fewer leaves than base->ne[1]).
+bool is_moe_expert_sum_add(const ggml_tensor * node) {
+    std::vector<const ggml_tensor *> leaves;
+    const ggml_tensor * cur = node;
+    while (cur->op == GGML_OP_ADD) {
+        if (cur->src[0] == nullptr || cur->src[1] == nullptr) {
+            return false;
+        }
+        leaves.push_back(cur->src[1]);
+        cur = cur->src[0];
+    }
+    leaves.push_back(cur);
+
+    const ggml_tensor * base = nullptr;
+    std::set<int64_t> plane_indices;
+    for (const ggml_tensor * leaf : leaves) {
+        if (leaf->op != GGML_OP_VIEW || leaf->src[0] == nullptr) {
+            return false;
+        }
+        const ggml_tensor * leaf_base = leaf->src[0];
+        if (base == nullptr) {
+            base = leaf_base;
+        } else if (leaf_base != base) {
+            return false;
+        }
+        if (leaf->ne[0] != base->ne[0] || leaf->ne[1] != base->ne[2] || leaf->ne[2] != 1 || leaf->ne[3] != 1 ||
+            leaf->nb[1] != base->nb[2]) {
+            return false;
+        }
+        if (base->nb[1] == 0 || leaf->view_offs % base->nb[1] != 0) {
+            return false;
+        }
+        int64_t plane = static_cast<int64_t>(leaf->view_offs / base->nb[1]);
+        if (plane < 0 || plane >= base->ne[1] || !plane_indices.insert(plane).second) {
+            return false;
+        }
+    }
+
+    return base != nullptr && base->ne[1] > 1 && plane_indices.size() == static_cast<size_t>(base->ne[1]);
+}
 }  // namespace
 
 static std::string get_tensor_ov_name(const ggml_cgraph * cgraph, const ggml_tensor * tensor) {
@@ -376,6 +423,14 @@ int GgmlOvDecoder::compute_op_case(const ggml_tensor * node) const {
                    is_kvcache(node->src[1]->view_src, nullptr)) {
             // s_copy defrag remainder writeback: gathered extra state rows copied back into the cache
             op_case = 3;
+        }
+        break;
+    }
+    case GGML_OP_ADD: {
+        if (is_moe_expert_sum_add(node)) {
+            // Outermost ADD of a MoE expert-plane sum chain: translated as a single
+            // ReduceSum over the base tensor instead of N-1 chained Adds over N Slices.
+            op_case = 1;
         }
         break;
     }

--- a/ggml/src/ggml-openvino/openvino/op/add.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/add.cpp
@@ -1,0 +1,45 @@
+#include "../node_context.h"
+#include "../op_table.h"
+#include "../utils.h"
+
+#include <memory>
+#include <openvino/op/add.hpp>
+#include <openvino/op/constant.hpp>
+#include <openvino/op/reduce_sum.hpp>
+#include <openvino/op/unsqueeze.hpp>
+
+namespace ov {
+namespace frontend {
+namespace ggml {
+namespace op {
+
+OutputVector translate_add(const NodeContext & context) {
+    num_inputs_check(context, 2, 2);
+
+    if (context.get_op_case() == 1) {
+        // MoE expert-plane sum (see is_moe_expert_sum_add): input 1 is a VIEW plane of the
+        // shared base tensor `experts` = [n_embd, n_expert_used, n_tokens, 1] (ggml order) ->
+        // [1, n_tokens, n_expert_used, n_embd] (OV order). The whole ADD chain is equivalent to
+        // reducing the expert axis (OV axis 2) of that base, so bypass the chain and the
+        // per-plane Slices entirely.
+        size_t view_size = context.get_view_input_size(1);
+        auto base_name = context.get_view_input_src_name(1, view_size - 1);
+        auto base = context.get_input(base_name);
+
+        auto reduced = std::make_shared<ov::op::v1::ReduceSum>(
+            base, ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {2}), false);
+        auto res =
+            std::make_shared<ov::op::v0::Unsqueeze>(reduced, ov::op::v0::Constant::create(ov::element::i64, {1}, {1}));
+        return rename_outputs_with_suffix({res}, context.get_name());
+    }
+
+    auto input_0 = process_view_input_new(context, 0);
+    auto input_1 = process_view_input_new(context, 1);
+    auto res = std::make_shared<ov::op::v1::Add>(input_0, input_1);
+    return rename_outputs_with_suffix({res}, context.get_name());
+}
+
+}  // namespace op
+}  // namespace ggml
+}  // namespace frontend
+}  // namespace ov

--- a/ggml/src/ggml-openvino/openvino/op_table.cpp
+++ b/ggml/src/ggml-openvino/openvino/op_table.cpp
@@ -21,7 +21,7 @@ namespace ggml {
 std::unordered_map<std::string, CreatorFunction> get_supported_ops() {
     using namespace ov::op;
     return {
-        {"GGML_OP_ADD",             op::translate_1to1_match_2_inputs<v1::Add>     },
+        {"GGML_OP_ADD",             op::translate_add                              },
         {"GGML_OP_ADD1",            op::translate_1to1_match_2_inputs<v1::Add>     },
         {"GGML_OP_ADD_ID",          op::translate_add_id                           },
         {"GGML_OP_CONCAT",          op::translate_concat                           },

--- a/ggml/src/ggml-openvino/openvino/op_table.h
+++ b/ggml/src/ggml-openvino/openvino/op_table.h
@@ -10,6 +10,7 @@ namespace op {
 
 #define GGML_OP_CONVERTER(op) OutputVector op(const NodeContext & context)
 
+GGML_OP_CONVERTER(translate_add);
 GGML_OP_CONVERTER(translate_cont);
 GGML_OP_CONVERTER(translate_concat);
 GGML_OP_CONVERTER(translate_add_id);


### PR DESCRIPTION
On top of the Qwen35 moe PR.

Optimizes MoE expert aggregation in the OpenVINO backend. It detects the final `ADD` in the structurally identified expert-view aggregation chain and translates it as a single `ReduceSum` over the expert dimension, instead of materializing individual expert views and chaining multiple additions.

<img width="1314" height="1150" alt="image" src="https://github.com/user-attachments/assets/2ad7aaf9-a5b6-4044-a589-79eee7b67ad3" />
