### PR TITLE
Fix error in arch test model due to cpy

### DIFF
--- a/ggml/src/ggml-openvino/openvino/op/cpy.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/cpy.cpp
@@ -4,6 +4,7 @@
 
 #include <climits>
 #include <memory>
+#include <vector>
 #include <openvino/op/add.hpp>
 #include <openvino/op/concat.hpp>
 #include <openvino/op/constant.hpp>
@@ -78,6 +79,7 @@ OutputVector translate_cpy(const NodeContext & context) {
 
         ov::Output<ov::Node> src;
         ov::Output<ov::Node> begin = context.get_input(slot_begin_name);
+        auto base = context.get_input(1);
         if (op_case == 1) {
             // GDN packs [attn | state snapshots]; the state part runs from src_begin to the end.
             auto src_begin = context.get_input("rs_src_begin_" + context.get_name());
@@ -92,7 +94,48 @@ OutputVector translate_cpy(const NodeContext & context) {
                 src_begin, ov::op::v0::Constant::create(ov::element::i64, {1}, {window_size}));
             auto window = std::make_shared<ov::op::v8::Slice>(context.get_input(0), src_begin, src_end, one,
                                                               ov::op::v0::Constant::create(ov::element::i64, {1}, {3}));
-            src = std::make_shared<ov::op::v1::Reshape>(window, feature, false);
+            const auto base_shape = base.get_partial_shape();
+            FRONT_END_OP_CONVERSION_CHECK(base_shape.rank().is_static() && base_shape.rank().get_length() == 4,
+                                          "CPY conv state cache update requires rank-4 base cache");
+            FRONT_END_OP_CONVERSION_CHECK(base_shape[3].is_static(),
+                                          "CPY conv state cache update requires static feature size");
+            FRONT_END_OP_CONVERSION_CHECK(input_shape.rank().is_static() && input_shape.rank().get_length() == 4 &&
+                                              input_shape[2].is_static() && input_shape[3].is_static(),
+                                          "CPY conv state cache update requires static source feature view");
+
+            const int64_t full_feature_size = base_shape[3].get_length();
+            const int64_t update_feature_size = input_shape[2].get_length() * input_shape[3].get_length();
+            const auto output_stride = context.get_output_stride();
+            const size_t elem_size = output_stride.empty() ? context.get_output_type().size() : output_stride.back();
+            FRONT_END_OP_CONVERSION_CHECK(elem_size > 0,
+                                          "CPY conv state cache update has invalid element size");
+            const int64_t feature_begin = static_cast<int64_t>(context.get_output_op_offset() / elem_size) %
+                                          full_feature_size;
+            const int64_t feature_end = feature_begin + update_feature_size;
+            FRONT_END_OP_CONVERSION_CHECK(feature_begin >= 0 && feature_end <= full_feature_size,
+                                          "CPY conv state cache update feature range is out of bounds");
+
+            auto partial_feature = ov::op::v0::Constant::create(
+                ov::element::i64, {4}, std::vector<int64_t>{1, 1, -1, update_feature_size});
+            src = std::make_shared<ov::op::v1::Reshape>(window, partial_feature, false);
+            if (src.get_element_type() != context.get_output_type()) {
+                src = std::make_shared<ov::op::v0::Convert>(src, context.get_output_type());
+            }
+
+            auto src_len = std::make_shared<ov::op::v8::Gather>(
+                std::make_shared<ov::op::v3::ShapeOf>(src, ov::element::i64), axis,
+                ov::op::v0::Constant::create(ov::element::i64, {}, {0}));
+            auto slot_end = std::make_shared<ov::op::v1::Add>(begin, src_len);
+            auto active_slots = std::make_shared<ov::op::v8::Slice>(base, begin, slot_end, one, axis);
+
+            auto feature_axis = ov::op::v0::Constant::create(ov::element::i64, {1}, {3});
+            auto feature_begin_node = ov::op::v0::Constant::create(ov::element::i64, {1}, {feature_begin});
+            auto feature_end_node = ov::op::v0::Constant::create(ov::element::i64, {1}, {feature_end});
+            auto feature_head = std::make_shared<ov::op::v8::Slice>(active_slots, zero, feature_begin_node, one,
+                                                                    feature_axis);
+            auto feature_tail = std::make_shared<ov::op::v8::Slice>(active_slots, feature_end_node, int_max, one,
+                                                                    feature_axis);
+            src = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{feature_head, src, feature_tail}, 3);
         } else {
             // op_case 3: gathered remainder rows already have the cache slot layout [1, 1, extra, feature]
             src = context.get_input(0);
@@ -102,7 +145,6 @@ OutputVector translate_cpy(const NodeContext & context) {
             src = std::make_shared<ov::op::v0::Convert>(src, context.get_output_type());
         }
 
-        auto base = context.get_input(1);
         auto src_len =
             std::make_shared<ov::op::v8::Gather>(std::make_shared<ov::op::v3::ShapeOf>(src, ov::element::i64), axis,
                                                  ov::op::v0::Constant::create(ov::element::i64, {}, {0}));


### PR DESCRIPTION
This pull request enhances the `translate_cpy` function in `cpy.cpp` to better support convolutional state cache updates and ensure correctness through additional shape and bounds checks. The main focus is on handling rank-4 tensors with static feature sizes and updating only the required feature slices efficiently.

**Enhancements for convolutional state cache updates:**

* Added multiple runtime checks to ensure that the base cache and source views are rank-4 tensors with static shapes, and that feature ranges are within bounds.
* Improved the logic to compute and update only the necessary feature slice within the cache, including calculation of feature offsets and sizes, and concatenation of updated features with the unchanged head and tail.
* Ensured type consistency by converting the updated slice to the required output type if necessary.

**Code and dependency improvements:**

* Added `#include <vector>` to support new vector-based constant creation.
* Moved the retrieval of the `base` input to the top of the function for clarity and to support the new logic. [[1]](diffhunk://#diff-a2244c316a54596a7be3df12d539b87257fba1db0626fabff30a531141ee22caR82) [[2]](diffhunk://#diff-a2244c316a54596a7be3df12d539b87257fba1db0626fabff30a531141ee22caL105)## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
