### PR TITLE
Fix error in arch test model minimax-m3 for OpenVINO Backend

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -911,7 +911,31 @@ static bool mul_mat_id_requires_large_tmp(const ggml_tensor * op) {
     return tmp_bytes > mul_mat_id_tmp_limit;
 }
 
+static bool tensor_name_starts_with(const ggml_tensor * tensor, const char * prefix) {
+    return tensor != nullptr && strncmp(tensor->name, prefix, strlen(prefix)) == 0;
+}
+
+static bool is_msa_block_mask_expansion(const ggml_tensor * op) {
+    if (tensor_name_starts_with(op, "msa_")) {
+        return true;
+    }
+
+    const ggml_tensor * src = op->src[0];
+    while (src != nullptr && (src->op == GGML_OP_RESHAPE || src->op == GGML_OP_REPEAT)) {
+        if (tensor_name_starts_with(src, "msa_block_mask")) {
+            return true;
+        }
+        src = src->src[0];
+    }
+
+    return tensor_name_starts_with(src, "msa_block_mask");
+}
+
 static bool is_op_unsupported_case(const ggml_tensor * op) {
+    if (is_msa_block_mask_expansion(op)) {
+        return true;
+    }
+
     switch (op->op) {
     case GGML_OP_CONCAT: {
         if (op->type == GGML_TYPE_I64) {


### PR DESCRIPTION
This pull request introduces a new check to improve the detection of unsupported operations related to MSA (Masked Self-Attention) block mask expansion in the OpenVINO backend. The main focus is on identifying specific tensor naming patterns and operation sequences to handle these cases more robustly.

**Detection improvements for unsupported MSA block mask expansion:**

* Added the helper function `tensor_name_starts_with` to check if a tensor's name begins with a given prefix.
* Implemented `is_msa_block_mask_expansion` to detect tensors involved in MSA block mask expansion, by checking tensor names and traversing reshape/repeat operation chains.
* Updated `is_op_unsupported_case` to treat detected MSA block mask expansion cases as unsupported, improving error detection and handling.## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
