### PR TITLE
reject CPY with quantized destination as unsupported

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -1173,6 +1173,10 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
             // GGML_LOG_WARN("OpenVINO backend does not support CPY with non-contiguous data or bf16 types\n");
             return true;
         }
+        // CPY to a quantized destination (e.g. f32 -> q4_0) is numerically unstable with OpenVINO backend.
+        if (ggml_is_quantized(op->type)) {
+            return true;
+        }
         if (ggml_nelements(op->src[0]) != ggml_nelements(op->src[1])) {
             return true;
         }


### PR DESCRIPTION
Reject CPY with quantized destination as unsupported.
The OpenVINO backend runs f32->quantized CPY but produces inaccurate results on both CPU and GPU.
This fixes test-backend-ops in the gpu-openvino-low-perf CI.
